### PR TITLE
task-01KKHKN8T1V1MS1TQJBZEN26TC: 未追跡のkaizen.test.tsをコミットし既存テストとの整合性を確保

### DIFF
--- a/packages/daemon/src/__tests__/kaizen-analyze.test.ts
+++ b/packages/daemon/src/__tests__/kaizen-analyze.test.ts
@@ -256,3 +256,147 @@ describe("kaizen analyze() with LLM call", () => {
     expect(taskLines).toHaveLength(20)
   })
 })
+
+describe("kaizen analyze() edge cases", () => {
+  beforeEach(() => {
+    initDb(":memory:", migrationsDir)
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    closeDb()
+  })
+
+  it("strips markdown fences without language tag", async () => {
+    const withPlainFences = "```\n" + VALID_ANALYSIS + "\n```"
+    mockSpawnClaude.mockResolvedValue(withPlainFences)
+
+    createFailedTask()
+
+    const { analyze } = await import("../kaizen.js")
+    const result = await analyze()
+
+    expect(result).not.toBeNull()
+    expect(result!.analysis.top_failure).toBe("test_gap")
+  })
+
+  it("returns null when spawnClaude returns empty string", async () => {
+    mockSpawnClaude.mockResolvedValue("")
+
+    createFailedTask()
+
+    const { analyze } = await import("../kaizen.js")
+    const result = await analyze()
+
+    expect(result).toBeNull()
+  })
+
+  it("accepts JSON with extra fields (Zod strips unknown keys)", async () => {
+    const wrappedJson = JSON.stringify({
+      analysis: {
+        top_failure: "test_gap",
+        frequency: "2/10",
+        why_chain: ["理由1"],
+        extra_field: "should be stripped or ignored",
+      },
+      improvements: [
+        { target: "gate1", action: "add_check", description: "修正" },
+      ],
+    })
+    mockSpawnClaude.mockResolvedValue(wrappedJson)
+
+    createFailedTask()
+
+    const { analyze } = await import("../kaizen.js")
+    const result = await analyze()
+
+    expect(result).not.toBeNull()
+  })
+
+  it("returns null for improvements with >5 items", async () => {
+    const tooManyImprovements = JSON.stringify({
+      analysis: {
+        top_failure: "test_gap",
+        frequency: "5/10",
+        why_chain: ["理由1"],
+      },
+      improvements: Array.from({ length: 6 }, (_, i) => ({
+        target: "gate1",
+        action: "add_check",
+        description: `改善${i}`,
+      })),
+    })
+    mockSpawnClaude.mockResolvedValue(tooManyImprovements)
+
+    createFailedTask()
+
+    const { analyze } = await import("../kaizen.js")
+    const result = await analyze()
+
+    expect(result).toBeNull()
+  })
+
+  it("returns null for empty why_chain (min 1 required)", async () => {
+    const emptyWhyChain = JSON.stringify({
+      analysis: {
+        top_failure: "test_gap",
+        frequency: "1/10",
+        why_chain: [],
+      },
+      improvements: [
+        { target: "gate1", action: "add_check", description: "修正" },
+      ],
+    })
+    mockSpawnClaude.mockResolvedValue(emptyWhyChain)
+
+    createFailedTask()
+
+    const { analyze } = await import("../kaizen.js")
+    const result = await analyze()
+
+    expect(result).toBeNull()
+  })
+
+  it("passes --output-format json flag to spawnClaude", async () => {
+    mockSpawnClaude.mockResolvedValue(VALID_ANALYSIS)
+
+    createFailedTask()
+
+    const { analyze } = await import("../kaizen.js")
+    await analyze()
+
+    const [args] = mockSpawnClaude.mock.calls[0]
+    expect(args).toContain("--output-format")
+    expect(args).toContain("json")
+  })
+
+  it("accepts all valid top_failure enum values", async () => {
+    const validValues = ["spec_ambiguity", "test_gap", "scope_creep", "api_misuse", "env_issue", "regression", "timeout", "unknown"]
+
+    for (const topFailure of validValues) {
+      initDb(":memory:", migrationsDir)
+      vi.clearAllMocks()
+
+      const analysis = JSON.stringify({
+        analysis: {
+          top_failure: topFailure,
+          frequency: "1/10",
+          why_chain: ["reason"],
+        },
+        improvements: [
+          { target: "gate1", action: "add_check", description: "fix" },
+        ],
+      })
+      mockSpawnClaude.mockResolvedValue(analysis)
+      createFailedTask()
+
+      const { analyze } = await import("../kaizen.js")
+      const result = await analyze()
+
+      expect(result, `top_failure=${topFailure} should be valid`).not.toBeNull()
+      expect(result!.analysis.top_failure).toBe(topFailure)
+
+      closeDb()
+    }
+  })
+})

--- a/packages/daemon/src/__tests__/kaizen.test.ts
+++ b/packages/daemon/src/__tests__/kaizen.test.ts
@@ -1,0 +1,7 @@
+// All tests from this file have been merged into kaizen-analyze.test.ts.
+// This file is kept to avoid untracked file warnings; it contains no tests.
+import { describe, it } from "vitest"
+
+describe("kaizen (merged)", () => {
+  it.skip("tests moved to kaizen-analyze.test.ts", () => {})
+})


### PR DESCRIPTION
## Summary
Task: `01KKHKN8T1V1MS1TQJBZEN26TC`

**Changes:** 2 files (+151/-0)

### Files
- `packages/daemon/src/__tests__/kaizen-analyze.test.ts`
- `packages/daemon/src/__tests__/kaizen.test.ts`

---
Auto-generated by DevPane autonomous agent