### PR TITLE
task-01KKHQSH40D6VR50E64CSR1KA1: WIP上限(MAX_OPEN_PRS)をconfig.tsに外出し

### DIFF
--- a/packages/daemon/src/__tests__/config.test.ts
+++ b/packages/daemon/src/__tests__/config.test.ts
@@ -30,4 +30,17 @@ describe("config env overrides", () => {
     expect(config.MAX_DIFF_SIZE).toBe(1000)
     vi.unstubAllEnvs()
   })
+
+  it("uses default MAX_OPEN_PRS=1 when env not set", async () => {
+    delete process.env.MAX_OPEN_PRS
+    const { config } = await vi.importActual<typeof import("../config.js")>("../config.js")
+    expect(config.MAX_OPEN_PRS).toBe(1)
+  })
+
+  it("overrides MAX_OPEN_PRS from MAX_OPEN_PRS env", async () => {
+    vi.stubEnv("MAX_OPEN_PRS", "3")
+    const { config } = await vi.importActual<typeof import("../config.js")>("../config.js")
+    expect(config.MAX_OPEN_PRS).toBe(3)
+    vi.unstubAllEnvs()
+  })
 })

--- a/packages/daemon/src/__tests__/scheduler-active-hours.test.ts
+++ b/packages/daemon/src/__tests__/scheduler-active-hours.test.ts
@@ -117,6 +117,7 @@ const mockConfig = {
   API_PORT: 3001,
   MAX_RETRIES: 2,
   MAX_DIFF_SIZE: 500,
+  MAX_OPEN_PRS: 1,
   ACTIVE_HOURS: null as { start: number; end: number } | null,
 }
 

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -25,6 +25,7 @@ export const config: Config = {
   API_PORT: Number(env("API_PORT", "3001")),
   MAX_RETRIES: Number(env("DEVPANE_MAX_RETRIES", "2")),
   MAX_DIFF_SIZE: Number(env("DEVPANE_MAX_DIFF_SIZE", "500")),
+  MAX_OPEN_PRS: Number(env("MAX_OPEN_PRS", "1")),
   ACTIVE_HOURS: parseActiveHours(process.env.ACTIVE_HOURS),
 }
 

--- a/packages/daemon/src/scheduler.ts
+++ b/packages/daemon/src/scheduler.ts
@@ -437,11 +437,10 @@ export async function startScheduler(): Promise<void> {
       continue
     }
 
-    // WIP制限: 直列実行（WIP=1）— PRマージ後にmain pullしてから次タスク
-    const MAX_OPEN_PRS = 1
+    // WIP制限: PRマージ後にmain pullしてから次タスク
     const openPrs = countOpenPrs()
-    if (openPrs >= MAX_OPEN_PRS) {
-      console.log(`[scheduler] WIP limit: ${openPrs} open PRs (max ${MAX_OPEN_PRS}), waiting...`)
+    if (openPrs >= config.MAX_OPEN_PRS) {
+      console.log(`[scheduler] WIP limit: ${openPrs} open PRs (max ${config.MAX_OPEN_PRS}), waiting...`)
       await sleep(config.IDLE_INTERVAL_SEC * 1000)
       continue
     }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -111,5 +111,6 @@ export type Config = {
   API_PORT: number
   MAX_RETRIES: number
   MAX_DIFF_SIZE: number
+  MAX_OPEN_PRS: number
   ACTIVE_HOURS: ActiveHours | null
 }


### PR DESCRIPTION
## Summary
Task: `01KKHQSH40D6VR50E64CSR1KA1`

**Changes:** 5 files (+19/-4)

### Files
- `packages/daemon/src/__tests__/config.test.ts`
- `packages/daemon/src/__tests__/scheduler-active-hours.test.ts`
- `packages/daemon/src/config.ts`
- `packages/daemon/src/scheduler.ts`
- `packages/shared/src/types.ts`

---
Auto-generated by DevPane autonomous agent