### PR TITLE
task-01KKHQSH40G7N5WC58SY0DQGZE: TesterのテストファイルパスをCLIのtool_useイベントから正確に抽出

### DIFF
--- a/packages/daemon/src/__tests__/tester.test.ts
+++ b/packages/daemon/src/__tests__/tester.test.ts
@@ -71,4 +71,302 @@ describe("parseTesterOutput", () => {
     const files = parseTesterOutput(lines)
     expect(files).toContain("packages/daemon/src/__tests__/deep/nested.test.ts")
   })
+
+  describe("tool_use event file_path extraction", () => {
+    it("extracts test file path from Write tool_use via input_json_delta", () => {
+      const lines = [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", name: "Write" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: {
+              type: "input_json_delta",
+              partial_json: '{"file_path": "/work/src/__tests__/auth.test.ts",',
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: {
+              type: "input_json_delta",
+              partial_json: '"content": "import { describe } from \\"vitest\\""}',
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop" },
+        }),
+      ].join("\n")
+
+      const files = parseTesterOutput(lines)
+      expect(files).toContain("/work/src/__tests__/auth.test.ts")
+    })
+
+    it("extracts test file path from Edit tool_use via input_json_delta", () => {
+      const lines = [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", name: "Edit" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: {
+              type: "input_json_delta",
+              partial_json: '{"file_path": "/work/src/__tests__/utils.test.ts",',
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop" },
+        }),
+      ].join("\n")
+
+      const files = parseTesterOutput(lines)
+      expect(files).toContain("/work/src/__tests__/utils.test.ts")
+    })
+
+    it("ignores non-test file paths from tool_use events", () => {
+      const lines = [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", name: "Write" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: {
+              type: "input_json_delta",
+              partial_json: '{"file_path": "/work/src/utils.ts",',
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop" },
+        }),
+      ].join("\n")
+
+      const files = parseTesterOutput(lines)
+      expect(files).toEqual([])
+    })
+
+    it("extracts multiple test files from sequential tool_use events", () => {
+      const lines = [
+        // First Write
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", name: "Write" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: {
+              type: "input_json_delta",
+              partial_json: '{"file_path": "/work/src/__tests__/first.test.ts"}',
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop" },
+        }),
+        // Second Write
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", name: "Write" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: {
+              type: "input_json_delta",
+              partial_json: '{"file_path": "/work/src/__tests__/second.test.ts"}',
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop" },
+        }),
+      ].join("\n")
+
+      const files = parseTesterOutput(lines)
+      expect(files).toContain("/work/src/__tests__/first.test.ts")
+      expect(files).toContain("/work/src/__tests__/second.test.ts")
+      expect(files).toHaveLength(2)
+    })
+
+    it("deduplicates paths from tool_use and result events", () => {
+      const lines = [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", name: "Write" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: {
+              type: "input_json_delta",
+              partial_json: '{"file_path": "src/__tests__/dup.test.ts"}',
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop" },
+        }),
+        JSON.stringify({
+          type: "result",
+          result: "Created src/__tests__/dup.test.ts",
+        }),
+      ].join("\n")
+
+      const files = parseTesterOutput(lines)
+      expect(files).toEqual(["src/__tests__/dup.test.ts"])
+    })
+
+    it("assembles file_path from fragmented input_json_delta chunks", () => {
+      const lines = [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", name: "Write" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: {
+              type: "input_json_delta",
+              partial_json: '{"file_',
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: {
+              type: "input_json_delta",
+              partial_json: 'path": "/work/src/__tests__/frag.test.ts"',
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: {
+              type: "input_json_delta",
+              partial_json: ', "content": "test code"}',
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop" },
+        }),
+      ].join("\n")
+
+      const files = parseTesterOutput(lines)
+      expect(files).toContain("/work/src/__tests__/frag.test.ts")
+    })
+
+    it("ignores tool_use events for non Write/Edit tools", () => {
+      const lines = [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", name: "Read" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: {
+              type: "input_json_delta",
+              partial_json: '{"file_path": "/work/src/__tests__/read.test.ts"}',
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop" },
+        }),
+      ].join("\n")
+
+      const files = parseTesterOutput(lines)
+      expect(files).toEqual([])
+    })
+
+    it("tool_use extraction works even when result text has no file paths", () => {
+      const lines = [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", name: "Write" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: {
+              type: "input_json_delta",
+              partial_json: '{"file_path": "/work/src/__tests__/solo.test.ts", "content": "code"}',
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop" },
+        }),
+        JSON.stringify({
+          type: "result",
+          result: "Done. All tests generated successfully.",
+        }),
+      ].join("\n")
+
+      const files = parseTesterOutput(lines)
+      expect(files).toContain("/work/src/__tests__/solo.test.ts")
+      expect(files).toHaveLength(1)
+    })
+  })
 })

--- a/packages/daemon/src/tester.ts
+++ b/packages/daemon/src/tester.ts
@@ -51,15 +51,27 @@ export function buildTesterPrompt(spec: PmOutput): string {
   ].join("\n")
 }
 
+function addTestFile(testFiles: string[], filePath: string): void {
+  if (filePath.endsWith(".test.ts") && !testFiles.includes(filePath)) {
+    testFiles.push(filePath)
+  }
+}
+
+function extractFilePathFromJson(json: string): string | null {
+  const match = json.match(/"file_path"\s*:\s*"([^"]+)"/)
+  return match ? match[1] : null
+}
+
 export function parseTesterOutput(stdout: string): string[] {
   const testFiles: string[] = []
+  let trackingToolUse = false
+  let jsonBuffer = ""
 
   for (const line of stdout.split("\n")) {
     if (!line.trim()) continue
     try {
       const event = JSON.parse(line)
 
-      // Track file writes to *.test.ts files
       if (event.type === "stream_event") {
         const inner = event.event
         if (
@@ -67,7 +79,29 @@ export function parseTesterOutput(stdout: string): string[] {
           inner.content_block?.type === "tool_use" &&
           (inner.content_block.name === "Write" || inner.content_block.name === "Edit")
         ) {
-          // File path will be in subsequent input_json_delta events
+          trackingToolUse = true
+          jsonBuffer = ""
+        } else if (
+          inner?.type === "content_block_start" &&
+          inner.content_block?.type === "tool_use"
+        ) {
+          trackingToolUse = false
+          jsonBuffer = ""
+        }
+
+        if (
+          trackingToolUse &&
+          inner?.type === "content_block_delta" &&
+          inner.delta?.type === "input_json_delta"
+        ) {
+          jsonBuffer += inner.delta.partial_json
+        }
+
+        if (inner?.type === "content_block_stop" && trackingToolUse) {
+          const filePath = extractFilePathFromJson(jsonBuffer)
+          if (filePath) addTestFile(testFiles, filePath)
+          trackingToolUse = false
+          jsonBuffer = ""
         }
       }
 
@@ -76,7 +110,7 @@ export function parseTesterOutput(stdout: string): string[] {
         const matches = event.result.match(/[\w/.-]+\.test\.ts/g)
         if (matches) {
           for (const m of matches) {
-            if (!testFiles.includes(m)) testFiles.push(m)
+            addTestFile(testFiles, m)
           }
         }
       }
@@ -85,7 +119,7 @@ export function parseTesterOutput(stdout: string): string[] {
       const matches = line.match(/[\w/.-]+\.test\.ts/g)
       if (matches) {
         for (const m of matches) {
-          if (!testFiles.includes(m)) testFiles.push(m)
+          addTestFile(testFiles, m)
         }
       }
     }
@@ -119,6 +153,8 @@ export function runTester(spec: PmOutput, worktreePath: string): Promise<TesterR
 
     const testFiles: string[] = []
     let lastActivity = Date.now()
+    let trackingToolUse = false
+    let jsonBuffer = ""
 
     const rl = createInterface({ input: proc.stdout })
 
@@ -129,11 +165,44 @@ export function runTester(spec: PmOutput, worktreePath: string): Promise<TesterR
       try {
         const event = JSON.parse(line)
 
+        if (event.type === "stream_event") {
+          const inner = event.event
+          if (
+            inner?.type === "content_block_start" &&
+            inner.content_block?.type === "tool_use" &&
+            (inner.content_block.name === "Write" || inner.content_block.name === "Edit")
+          ) {
+            trackingToolUse = true
+            jsonBuffer = ""
+          } else if (
+            inner?.type === "content_block_start" &&
+            inner.content_block?.type === "tool_use"
+          ) {
+            trackingToolUse = false
+            jsonBuffer = ""
+          }
+
+          if (
+            trackingToolUse &&
+            inner?.type === "content_block_delta" &&
+            inner.delta?.type === "input_json_delta"
+          ) {
+            jsonBuffer += inner.delta.partial_json
+          }
+
+          if (inner?.type === "content_block_stop" && trackingToolUse) {
+            const filePath = extractFilePathFromJson(jsonBuffer)
+            if (filePath) addTestFile(testFiles, filePath)
+            trackingToolUse = false
+            jsonBuffer = ""
+          }
+        }
+
         if (event.type === "result" && event.result) {
           const matches = event.result.match(/[\w/.-]+\.test\.ts/g)
           if (matches) {
             for (const m of matches) {
-              if (!testFiles.includes(m)) testFiles.push(m)
+              addTestFile(testFiles, m)
             }
           }
         }


### PR DESCRIPTION
## Summary
Task: `01KKHQSH40G7N5WC58SY0DQGZE`

**Changes:** 2 files (+372/-5)

### Files
- `packages/daemon/src/__tests__/tester.test.ts`
- `packages/daemon/src/tester.ts`

---
Auto-generated by DevPane autonomous agent