### PR TITLE
task-01KKKZWM52CY1AQ75HZ76QESNT: events.tsのnotifier失敗とworktree.tsのcountOpenPrs失敗にログ出力を追加

### DIFF
--- a/packages/daemon/src/__tests__/silent-errors.test.ts
+++ b/packages/daemon/src/__tests__/silent-errors.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+
+vi.mock("@devpane/shared/schemas", () => ({
+  AgentEventSchema: { safeParse: vi.fn() },
+}))
+
+vi.mock("../db.js", () => ({
+  insertAgentEvent: vi.fn(),
+  getDb: vi.fn(),
+  getTask: vi.fn().mockReturnValue({ title: "テストタスク" }),
+}))
+
+vi.mock("../ws.js", () => ({
+  broadcast: vi.fn(),
+}))
+
+vi.mock("../config.js", () => ({
+  config: {
+    PROJECT_ROOT: "/tmp/test-project",
+  },
+}))
+
+describe("silent error logging", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  describe("events.ts: notifier failure logging", () => {
+    it("logs console.warn when notifier.notify rejects", async () => {
+      const notifyError = new Error("webhook timeout")
+      vi.doMock("../notifier-factory.js", () => ({
+        getNotifier: () => ({
+          notify: vi.fn().mockRejectedValue(notifyError),
+        }),
+      }))
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+      const { emit } = await import("../events.js")
+
+      emit({ type: "task.completed", taskId: "t-001", costUsd: 0.01 })
+
+      await vi.waitFor(() => {
+        expect(warnSpy).toHaveBeenCalledWith("[notifier] failed:", notifyError)
+      })
+    })
+  })
+
+  describe("worktree.ts: countOpenPrs failure logging", () => {
+    it("logs console.warn when gh CLI fails", async () => {
+      const ghError = new Error("gh: command not found")
+      vi.doMock("node:child_process", () => ({
+        execFileSync: vi.fn().mockImplementation(() => {
+          throw ghError
+        }),
+      }))
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+      const { countOpenPrs } = await import("../worktree.js")
+
+      const result = countOpenPrs()
+
+      expect(result).toBe(0)
+      expect(warnSpy).toHaveBeenCalledWith("[worktree] countOpenPrs failed:", ghError)
+    })
+  })
+})

--- a/packages/daemon/src/events.ts
+++ b/packages/daemon/src/events.ts
@@ -19,7 +19,7 @@ function getQuerySinceStmt() {
 export function emit(event: AgentEvent): void {
   insertAgentEvent(event.type, event)
   broadcast("event", event)
-  getNotifier().notify(event).catch(() => {})
+  getNotifier().notify(event).catch((err) => { console.warn('[notifier] failed:', err) })
 }
 
 export function safeEmit(raw: unknown): boolean {

--- a/packages/daemon/src/worktree.ts
+++ b/packages/daemon/src/worktree.ts
@@ -185,7 +185,8 @@ export function countOpenPrs(): number {
     }).trim()
     const prs = JSON.parse(result)
     return Array.isArray(prs) ? prs.length : 0
-  } catch {
+  } catch (err) {
+    console.warn('[worktree] countOpenPrs failed:', err)
     return 0
   }
 }


### PR DESCRIPTION
## Summary
Task: `01KKKZWM52CY1AQ75HZ76QESNT`

**Changes:** 3 files (+70/-2)

### Files
- `packages/daemon/src/__tests__/silent-errors.test.ts`
- `packages/daemon/src/events.ts`
- `packages/daemon/src/worktree.ts`

---
Auto-generated by DevPane autonomous agent