### PR TITLE
task-01KKKZWM52AREJDYRJ6JSF7RXX: pm.tsのJSON.parseにtry-catchを追加し失敗時のエラーメッセージを改善

### DIFF
--- a/packages/daemon/src/__tests__/pm-parse.test.ts
+++ b/packages/daemon/src/__tests__/pm-parse.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest"
+import { parsePmOutput } from "../pm.js"
+
+describe("parsePmOutput - JSON parse error handling", () => {
+  it("parses valid JSON correctly", () => {
+    const input = JSON.stringify({
+      tasks: [{ title: "Test task", description: "desc", priority: 1 }],
+      reasoning: "reason",
+    })
+    const result = parsePmOutput(input)
+    expect(result.tasks).toHaveLength(1)
+    expect(result.tasks[0].title).toBe("Test task")
+    expect(result.reasoning).toBe("reason")
+  })
+
+  it("throws with descriptive message when text contains no JSON", () => {
+    expect(() => parsePmOutput("plain text with no braces")).toThrow(
+      "PM output does not contain valid JSON",
+    )
+  })
+
+  it("throws with extracted snippet when regex matches invalid JSON", () => {
+    const input = "Here is output: {tasks: invalid, not real json} done"
+    expect(() => parsePmOutput(input)).toThrow("PM output contains invalid JSON")
+    expect(() => parsePmOutput(input)).toThrow("{tasks: invalid, not real json}")
+  })
+
+  it("truncates long invalid JSON snippet to 200 chars in error message", () => {
+    const longValue = "x".repeat(300)
+    const input = `{tasks: ${longValue}}`
+    try {
+      parsePmOutput(input)
+      expect.unreachable("should have thrown")
+    } catch (e) {
+      const msg = (e as Error).message
+      expect(msg).toContain("PM output contains invalid JSON")
+      expect(msg.length).toBeLessThan(300)
+    }
+  })
+})

--- a/packages/daemon/src/pm.ts
+++ b/packages/daemon/src/pm.ts
@@ -128,7 +128,12 @@ export function parsePmOutput(stdout: string): PmOutput {
   const match = text.match(/\{[\s\S]*\}/)
   if (!match) throw new Error(`PM output does not contain valid JSON: ${text.slice(0, 200)}`)
 
-  const parsed = JSON.parse(match[0])
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(match[0])
+  } catch {
+    throw new Error(`PM output contains invalid JSON: ${match[0].slice(0, 200)}`)
+  }
 
   // Contract: Zodスキーマでバリデーション（原理3）
   const result = PmOutputSchema.safeParse(parsed)


### PR DESCRIPTION
## Summary
Task: `01KKKZWM52AREJDYRJ6JSF7RXX`

**Changes:** 2 files (+46/-1)

### Files
- `packages/daemon/src/__tests__/pm-parse.test.ts`
- `packages/daemon/src/pm.ts`

---
Auto-generated by DevPane autonomous agent