### PR TITLE
task-01KKM1FNCPQP0TX5HD8D85BQBB: shutdown時のkillAllTesters未呼び出しとGate3イベント二重発火の修正

### DIFF
--- a/packages/daemon/src/__tests__/gate3-no-emit.test.ts
+++ b/packages/daemon/src/__tests__/gate3-no-emit.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import { initDb, closeDb } from "../db.js"
+import type { ObservableFacts } from "@devpane/shared"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsDir = join(__dirname, "..", "..", "src", "migrations")
+
+// emit をモックして呼び出しを監視
+const mockEmit = vi.fn()
+vi.mock("../events.js", () => ({
+  emit: mockEmit,
+  safeEmit: vi.fn(() => true),
+}))
+
+function makeFacts(overrides: Partial<ObservableFacts> = {}): ObservableFacts {
+  return {
+    exit_code: 0,
+    files_changed: ["src/foo.ts"],
+    diff_stats: { additions: 10, deletions: 2 },
+    branch: "devpane/task-test",
+    commit_hash: "abc123",
+    ...overrides,
+  }
+}
+
+describe("gate3 does not emit events", () => {
+  beforeEach(() => {
+    initDb(":memory:", migrationsDir)
+    mockEmit.mockClear()
+  })
+
+  afterEach(() => {
+    closeDb()
+  })
+
+  it("does not call emit on verdict=go", async () => {
+    const { runGate3 } = await import("../gate.js")
+    const result = runGate3("test-no-emit-1", makeFacts())
+
+    expect(result.verdict).toBe("go")
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it("does not call emit on verdict=kill", async () => {
+    const { runGate3 } = await import("../gate.js")
+    const result = runGate3("test-no-emit-2", makeFacts({ exit_code: 1 }))
+
+    expect(result.verdict).toBe("kill")
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it("does not call emit on verdict=recycle", async () => {
+    const { runGate3 } = await import("../gate.js")
+    const result = runGate3("test-no-emit-3", makeFacts({
+      test_result: { passed: 5, failed: 2, exit_code: 1 },
+    }))
+
+    expect(result.verdict).toBe("recycle")
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+})

--- a/packages/daemon/src/__tests__/shutdown-kill-testers.test.ts
+++ b/packages/daemon/src/__tests__/shutdown-kill-testers.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest"
+
+// index.ts の shutdown() が killAllTesters を呼び出すことを検証する。
+// 直接 shutdown() を呼ぶのではなく、ソースコードの静的検査で担保する。
+
+vi.mock("../events.js", () => ({
+  emit: vi.fn(),
+  safeEmit: vi.fn(() => true),
+}))
+
+vi.mock("../ws.js", () => ({
+  broadcast: vi.fn(),
+}))
+
+describe("shutdown includes killAllTesters", () => {
+  it("index.ts imports killAllTesters from tester.js", async () => {
+    const fs = await import("node:fs")
+    const path = await import("node:path")
+    const { fileURLToPath } = await import("node:url")
+
+    const indexPath = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "index.ts",
+    )
+    const source = fs.readFileSync(indexPath, "utf-8")
+
+    expect(source).toMatch(/import\s*\{[^}]*killAllTesters[^}]*\}\s*from\s*["']\.\/tester/)
+  })
+
+  it("shutdown() calls killAllTesters", async () => {
+    const fs = await import("node:fs")
+    const path = await import("node:path")
+    const { fileURLToPath } = await import("node:url")
+
+    const indexPath = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "index.ts",
+    )
+    const source = fs.readFileSync(indexPath, "utf-8")
+
+    // shutdown 関数の本体を抽出して killAllTesters 呼び出しを確認
+    const shutdownMatch = source.match(/async\s+function\s+shutdown\s*\(\)\s*\{([\s\S]*?)\n\}/)
+    expect(shutdownMatch).not.toBeNull()
+
+    const shutdownBody = shutdownMatch![1]
+    expect(shutdownBody).toContain("killAllTesters()")
+  })
+})

--- a/packages/daemon/src/gate.ts
+++ b/packages/daemon/src/gate.ts
@@ -1,6 +1,5 @@
 import type { ObservableFacts } from "@devpane/shared"
 import type { Gate3Verdict, StructuredFailure, RootCauseType } from "@devpane/shared/schemas"
-import { emit } from "./events.js"
 import { appendLog } from "./db.js"
 import { config } from "./config.js"
 
@@ -55,12 +54,9 @@ export function runGate3(taskId: string, facts: ObservableFacts): Gate3Result {
     reasons.push("no files changed")
   }
 
-  // Emit event
   if (verdict === "go") {
-    emit({ type: "gate.passed", taskId, gate: "gate3" })
     appendLog(taskId, "gate3", `[pass] ${reasons.length === 0 ? "all checks passed" : reasons.join(", ")}`)
   } else {
-    emit({ type: "gate.rejected", taskId, gate: "gate3", verdict, reason: reasons.join("; ") })
     appendLog(taskId, "gate3", `[${verdict}] ${reasons.join("; ")}`)
   }
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -13,6 +13,7 @@ import { attachWebSocket } from "./ws.js"
 import { startScheduler, stopScheduler } from "./scheduler.js"
 import { killAllWorkers } from "./worker.js"
 import { killAllPm } from "./pm.js"
+import { killAllTesters } from "./tester.js"
 
 const app = new Hono()
 
@@ -45,6 +46,7 @@ async function shutdown() {
   await stopScheduler()
   killAllWorkers()
   killAllPm()
+  killAllTesters()
   process.exit(0)
 }
 


### PR DESCRIPTION
## Summary
Task: `01KKM1FNCPQP0TX5HD8D85BQBB`

**Changes:** 4 files (+115/-4)

### Files
- `packages/daemon/src/__tests__/gate3-no-emit.test.ts`
- `packages/daemon/src/__tests__/shutdown-kill-testers.test.ts`
- `packages/daemon/src/gate.ts`
- `packages/daemon/src/index.ts`

---
Auto-generated by DevPane autonomous agent