### PR TITLE
task-01KKM314THVCAF7V838CZND25X: Gate1のgate.rejectedイベント二重発火を修正

### DIFF
--- a/packages/daemon/src/__tests__/gate-rejected-events.test.ts
+++ b/packages/daemon/src/__tests__/gate-rejected-events.test.ts
@@ -215,6 +215,24 @@ describe("gate.rejected → agent_events DB記録", () => {
     expect(rejected!.reason).toContain("tests failed")
   })
 
+  it("Gate1 kill時にgate.rejectedが1回だけ記録される（二重発火しない）", async () => {
+    const { executeTask } = await import("../scheduler.js")
+    mockRunGate1.mockResolvedValue({ verdict: "kill", reasons: ["duplicate task"] })
+    const task = makeTask()
+
+    await executeTask(task)
+
+    const events = getAgentEvents({ type: "gate.rejected" })
+    const gate1Rejected = events.filter(
+      (e) => e.type === "gate.rejected" && "gate" in e && e.gate === "gate1",
+    )
+    // gate1.ts側で1回だけemitされ、scheduler.ts側では重複emitしないこと
+    expect(gate1Rejected).toHaveLength(1)
+    const first = gate1Rejected[0] as Extract<AgentEvent, { type: "gate.rejected" }>
+    expect(first.taskId).toBe(task.id)
+    expect(first.verdict).toBe("kill")
+  })
+
   it("Gate1 go → agent_eventsにgate.rejectedが記録されない", async () => {
     const { executeTask } = await import("../scheduler.js")
     const task = makeTask()

--- a/packages/daemon/src/gate1.ts
+++ b/packages/daemon/src/gate1.ts
@@ -131,7 +131,6 @@ export async function runGate1(task: Task): Promise<Gate1Result> {
   // Phase 1: ルールベース
   const ruleResult = runGate1Rules(task)
   if (ruleResult.verdict === "kill") {
-    emit({ type: "gate.rejected", taskId: task.id, gate: "gate1", verdict: "kill", reason: ruleResult.reasons.join("; ") })
     appendLog(task.id, "gate1", `[kill:rule] ${ruleResult.reasons.join("; ")}`)
     return ruleResult
   }
@@ -141,7 +140,6 @@ export async function runGate1(task: Task): Promise<Gate1Result> {
   const llmResult = await runGate1Llm(task)
 
   if (llmResult.verdict === "kill") {
-    emit({ type: "gate.rejected", taskId: task.id, gate: "gate1", verdict: "kill", reason: llmResult.reasons.join("; ") })
     appendLog(task.id, "gate1", `[kill:llm] ${llmResult.reasons.join("; ")}`)
     return llmResult
   }
@@ -151,7 +149,6 @@ export async function runGate1(task: Task): Promise<Gate1Result> {
     return llmResult
   }
 
-  emit({ type: "gate.passed", taskId: task.id, gate: "gate1" })
   appendLog(task.id, "gate1", "[pass] rule + LLM checks passed")
   return { verdict: "go", reasons: [] }
 }


### PR DESCRIPTION
## Summary
Task: `01KKM314THVCAF7V838CZND25X`

**Changes:** 2 files (+18/-3)

### Files
- `packages/daemon/src/__tests__/gate-rejected-events.test.ts`
- `packages/daemon/src/gate1.ts`

---
Auto-generated by DevPane autonomous agent