### PR TITLE
task-01KKM3S37KXVH31DB621YWWCWW: Gate1 recycleのイベント未記録とfacts.tsビルド失敗のexit_code未反映を修正

### DIFF
--- a/packages/daemon/src/__tests__/facts-build-log.test.ts
+++ b/packages/daemon/src/__tests__/facts-build-log.test.ts
@@ -48,4 +48,18 @@ describe("collectFacts: pnpm build失敗時のログ記録", () => {
       expect.stringContaining("build"),
     )
   })
+
+  it("pnpm buildが失敗した場合、exit_codeが1に上書きされる", () => {
+    const facts = collectFacts("task-build-fail-2", "Fix types", "/tmp/worktree", 0)
+
+    // ビルド失敗時はexit_codeが0のままではなく1に反映されるべき
+    expect(facts.exit_code).toBe(1)
+  })
+
+  it("pnpm buildが失敗した場合、exit_codeが元のexit_code以上になる", () => {
+    // 元々exit_code=1の場合でも、ビルド失敗で上書きされても問題ない
+    const facts = collectFacts("task-build-fail-3", "Fix types", "/tmp/worktree", 1)
+
+    expect(facts.exit_code).toBeGreaterThanOrEqual(1)
+  })
 })

--- a/packages/daemon/src/__tests__/gate-rejected-events.test.ts
+++ b/packages/daemon/src/__tests__/gate-rejected-events.test.ts
@@ -233,6 +233,37 @@ describe("gate.rejected → agent_events DB記録", () => {
     expect(first.verdict).toBe("kill")
   })
 
+  it("Gate1 recycle → agent_eventsにgate.rejectedレコードが挿入される", async () => {
+    const { executeTask } = await import("../scheduler.js")
+    mockRunGate1.mockResolvedValue({ verdict: "recycle", reasons: ["needs clarification"] })
+    const task = makeTask()
+
+    await executeTask(task)
+
+    const events = getAgentEvents({ type: "gate.rejected" })
+    const rejected = events.find(
+      (e) => e.type === "gate.rejected" && "gate" in e && e.gate === "gate1",
+    ) as Extract<AgentEvent, { type: "gate.rejected" }> | undefined
+    expect(rejected).toBeTruthy()
+    expect(rejected!.taskId).toBe(task.id)
+    expect(rejected!.verdict).toBe("recycle")
+    expect(rejected!.reason).toContain("needs clarification")
+  })
+
+  it("Gate1 recycle → gate.rejectedが1回だけ記録される（二重発火しない）", async () => {
+    const { executeTask } = await import("../scheduler.js")
+    mockRunGate1.mockResolvedValue({ verdict: "recycle", reasons: ["ambiguous scope"] })
+    const task = makeTask()
+
+    await executeTask(task)
+
+    const events = getAgentEvents({ type: "gate.rejected" })
+    const gate1Rejected = events.filter(
+      (e) => e.type === "gate.rejected" && "gate" in e && e.gate === "gate1",
+    )
+    expect(gate1Rejected).toHaveLength(1)
+  })
+
   it("Gate1 go → agent_eventsにgate.rejectedが記録されない", async () => {
     const { executeTask } = await import("../scheduler.js")
     const task = makeTask()

--- a/packages/daemon/src/facts.ts
+++ b/packages/daemon/src/facts.ts
@@ -16,6 +16,7 @@ export function collectFacts(
   const { filesChanged, additions, deletions } = getWorktreeDiff(taskId)
 
   // Build first (required for monorepo — dist/ doesn't exist in worktree)
+  let buildFailed = false
   try {
     execFileSync("pnpm", ["build"], {
       cwd: worktreePath,
@@ -23,6 +24,7 @@ export function collectFacts(
       timeout: 120000,
     })
   } catch (e) {
+    buildFailed = true
     const buildErr = e as { stderr?: string; message?: string }
     const detail = buildErr.stderr || buildErr.message || "unknown build error"
     appendLog(taskId, "build", `[error] pnpm build failed: ${detail}`)
@@ -88,7 +90,7 @@ export function collectFacts(
   }
 
   return {
-    exit_code: exitCode,
+    exit_code: buildFailed ? Math.max(exitCode, 1) : exitCode,
     files_changed: filesChanged,
     diff_stats: { additions, deletions },
     test_result: testResult,

--- a/packages/daemon/src/scheduler.ts
+++ b/packages/daemon/src/scheduler.ts
@@ -234,6 +234,7 @@ export async function executeTask(task: Task): Promise<void> {
   }
   if (gate1.verdict === "recycle") {
     console.log(`[scheduler] Gate 1 RECYCLE task ${task.id}: ${gate1.reasons.join("; ")}`)
+    emit({ type: "gate.rejected", taskId: task.id, gate: "gate1", verdict: "recycle", reason: gate1.reasons.join("; ") })
     appendLog(task.id, "gate1", `[recycle] ${gate1.reasons.join("; ")}`)
     revertToPending(task.id)
     broadcast("task:updated", { id: task.id, status: "pending" })


### PR DESCRIPTION
## Summary
Task: `01KKM3S37KXVH31DB621YWWCWW`

**Changes:** 4 files (+49/-1)

### Files
- `packages/daemon/src/__tests__/facts-build-log.test.ts`
- `packages/daemon/src/__tests__/gate-rejected-events.test.ts`
- `packages/daemon/src/facts.ts`
- `packages/daemon/src/scheduler.ts`

---
Auto-generated by DevPane autonomous agent