### PR TITLE
task-01KKM3S37JXA434DD3YWT72G1W: scheduler-plugins.tsのinsertAgentEvent二重挿入とcircuit-breaker.tsのclosed遷移時emit誤発火を修正

### DIFF
--- a/packages/daemon/src/__tests__/circuit-breaker.test.ts
+++ b/packages/daemon/src/__tests__/circuit-breaker.test.ts
@@ -131,4 +131,57 @@ describe("CircuitBreaker", () => {
     // only 2 failures after reset, should still be closed
     expect(cb.getState()).toBe("closed")
   })
+
+  it("does not emit worker.rate_limited on transition to half-open", () => {
+    cb.recordFailure()
+    cb.recordFailure()
+    cb.recordFailure() // closed → open
+    vi.mocked(emit).mockClear()
+
+    // open → half-open (backoff elapsed)
+    now = 300 * 1000
+    cb.getState() // triggers maybeTransition → half-open
+    expect(cb.getState()).toBe("half-open")
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it("does not emit worker.rate_limited on transition to closed", () => {
+    cb.recordFailure()
+    cb.recordFailure()
+    cb.recordFailure() // closed → open
+    now = 300 * 1000
+    cb.canProceed() // open → half-open
+    vi.mocked(emit).mockClear()
+
+    cb.recordSuccess() // half-open → closed
+    expect(cb.getState()).toBe("closed")
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it("emits worker.rate_limited only on transitions to open", () => {
+    // closed → open (emit #1)
+    cb.recordFailure()
+    cb.recordFailure()
+    cb.recordFailure()
+
+    // open → half-open (no emit)
+    now = 300 * 1000
+    cb.canProceed()
+
+    // half-open → open (emit #2)
+    cb.recordFailure()
+
+    // open → half-open (no emit)
+    now += 600 * 1000
+    cb.canProceed()
+
+    // half-open → closed (no emit)
+    cb.recordSuccess()
+
+    // Only 2 emit calls — both for transitions to open
+    expect(emit).toHaveBeenCalledTimes(2)
+    for (const call of vi.mocked(emit).mock.calls) {
+      expect(call[0]).toMatchObject({ type: "worker.rate_limited" })
+    }
+  })
 })

--- a/packages/daemon/src/__tests__/kaizen-no-double-insert.test.ts
+++ b/packages/daemon/src/__tests__/kaizen-no-double-insert.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import { initDb, closeDb, getDb, createTask, startTask } from "../db.js"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsDir = join(__dirname, "..", "..", "src", "migrations")
+
+// Do NOT mock events.js — we want the real emit() to call insertAgentEvent
+// Instead, mock emit's downstream dependencies (ws, notifier)
+vi.mock("../ws.js", () => ({
+  broadcast: vi.fn(),
+}))
+
+vi.mock("../notifier-factory.js", () => ({
+  getNotifier: vi.fn(() => ({ notify: vi.fn(() => Promise.resolve()) })),
+}))
+
+vi.mock("../kaizen.js", () => ({
+  analyze: vi.fn(() => Promise.resolve({
+    analysis: {
+      top_failure: "test_gap",
+      frequency: "3/10",
+      why_chain: ["テストが不足"],
+    },
+    improvements: [
+      { target: "gate2", action: "add_check", description: "テストカバレッジ検証" },
+    ],
+  })),
+}))
+
+vi.mock("../memory.js", () => ({
+  remember: vi.fn(),
+  forget: vi.fn(),
+  findSimilar: vi.fn(() => []),
+  cleanupOldLessons: vi.fn(() => 0),
+}))
+
+vi.mock("../worktree.js", () => ({
+  getWorktreeNewAndDeleted: vi.fn(() => ({ added: [], deleted: [] })),
+}))
+
+vi.mock("../spc.js", () => ({
+  recordTaskMetrics: vi.fn(),
+  checkAllMetrics: vi.fn(() => []),
+}))
+
+type KaizenPluginExports = {
+  KAIZEN_THRESHOLD: number
+  resetKaizenCounter: () => void
+  setKaizenCounter: (n: number) => void
+  getKaizenCounter: () => number
+  checkKaizenAnalysis: () => Promise<void>
+}
+
+async function getKaizenExports(): Promise<KaizenPluginExports> {
+  return await import("../scheduler-plugins.js") as unknown as KaizenPluginExports
+}
+
+function createFinishedTask(status: "done" | "failed", finishedAt: string) {
+  const task = createTask("t", "d", "pm")
+  startTask(task.id, "worker-0")
+  const db = getDb()
+  const result = JSON.stringify({ exit_code: status === "done" ? 0 : 1, files_changed: [], diff_stats: { additions: 10, deletions: 5 } })
+  db.prepare(`UPDATE tasks SET status = ?, finished_at = ?, result = ?, cost_usd = ? WHERE id = ?`).run(
+    status, finishedAt, result, 0.1, task.id,
+  )
+}
+
+describe("kaizen: no double insert of improvement.applied", () => {
+  beforeEach(async () => {
+    initDb(":memory:", migrationsDir)
+    const mod = await getKaizenExports()
+    mod.resetKaizenCounter()
+  })
+
+  afterEach(() => {
+    closeDb()
+  })
+
+  it("inserts exactly 1 agent_event record per improvement (not 2)", async () => {
+    const mod = await getKaizenExports()
+
+    for (let i = 0; i < 5; i++) createFinishedTask("failed", "2024-07-01T00:00:00.000Z")
+
+    mod.setKaizenCounter(mod.KAIZEN_THRESHOLD)
+    await mod.checkKaizenAnalysis()
+
+    const db = getDb()
+    const events = db.prepare(
+      `SELECT * FROM agent_events WHERE type = 'improvement.applied'`,
+    ).all() as Array<{ type: string; payload: string }>
+
+    // emit() internally calls insertAgentEvent once.
+    // There must NOT be a second insertAgentEvent call in scheduler-plugins.ts.
+    expect(events).toHaveLength(1)
+  })
+
+  it("inserts exactly N agent_event records for N improvements", async () => {
+    const { analyze } = await import("../kaizen.js") as unknown as { analyze: ReturnType<typeof vi.fn> }
+    analyze.mockResolvedValueOnce({
+      analysis: { top_failure: "multi", frequency: "5/10", why_chain: ["a"] },
+      improvements: [
+        { target: "gate1", action: "fix_a", description: "a" },
+        { target: "gate2", action: "fix_b", description: "b" },
+        { target: "gate3", action: "fix_c", description: "c" },
+      ],
+    })
+
+    const mod = await getKaizenExports()
+    for (let i = 0; i < 5; i++) createFinishedTask("failed", "2024-07-01T00:00:00.000Z")
+
+    mod.setKaizenCounter(mod.KAIZEN_THRESHOLD)
+    await mod.checkKaizenAnalysis()
+
+    const db = getDb()
+    const events = db.prepare(
+      `SELECT * FROM agent_events WHERE type = 'improvement.applied'`,
+    ).all() as Array<{ type: string; payload: string }>
+
+    // Exactly 3 events — one per improvement, no duplicates
+    expect(events).toHaveLength(3)
+  })
+})

--- a/packages/daemon/src/__tests__/kaizen-scheduler.test.ts
+++ b/packages/daemon/src/__tests__/kaizen-scheduler.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { join, dirname } from "node:path"
 import { fileURLToPath } from "node:url"
 import type { AgentEvent } from "@devpane/shared/schemas"
-import { initDb, closeDb, getDb, createTask, startTask } from "../db.js"
+import { initDb, closeDb, getDb, createTask, startTask, insertAgentEvent } from "../db.js"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const migrationsDir = join(__dirname, "..", "..", "src", "migrations")
@@ -11,7 +11,11 @@ const migrationsDir = join(__dirname, "..", "..", "src", "migrations")
 const emittedEvents: AgentEvent[] = []
 
 vi.mock("../events.js", () => ({
-  emit: vi.fn((event: AgentEvent) => { emittedEvents.push(event) }),
+  emit: vi.fn((event: AgentEvent) => {
+    emittedEvents.push(event)
+    // Replicate real emit() behavior: persist to agent_events table
+    insertAgentEvent(event.type, event)
+  }),
   safeEmit: vi.fn(() => true),
 }))
 

--- a/packages/daemon/src/circuit-breaker.ts
+++ b/packages/daemon/src/circuit-breaker.ts
@@ -78,7 +78,9 @@ export class CircuitBreaker {
     if (to === "open") {
       this.openedAt = this.clock()
     }
-    emit({ type: "worker.rate_limited", backoffSec: this.currentBackoff })
+    if (to === "open") {
+      emit({ type: "worker.rate_limited", backoffSec: this.currentBackoff })
+    }
     console.log(`[circuit-breaker] ${from} → ${to} (backoff: ${this.currentBackoff}s)`)
   }
 }

--- a/packages/daemon/src/scheduler-plugins.ts
+++ b/packages/daemon/src/scheduler-plugins.ts
@@ -3,7 +3,7 @@ import { recordTaskMetrics, checkAllMetrics } from "./spc.js"
 import { emit, safeEmit } from "./events.js"
 import { remember, forget, findSimilar, cleanupOldLessons } from "./memory.js"
 import { getWorktreeNewAndDeleted } from "./worktree.js"
-import { getActiveImprovements, getFailedTasks, getDb, insertAgentEvent } from "./db.js"
+import { getActiveImprovements, getFailedTasks, getDb } from "./db.js"
 import { measureAllActive } from "./effect-measure.js"
 import { analyze } from "./kaizen.js"
 import { ulid } from "ulid"
@@ -94,7 +94,6 @@ export async function checkKaizenAnalysis(): Promise<void> {
 
     const event = { type: "improvement.applied" as const, improvementId: id, target: imp.target }
     emit(event)
-    insertAgentEvent("improvement.applied", event)
   }
 }
 


### PR DESCRIPTION
## Summary
Task: `01KKM3S37JXA434DD3YWT72G1W`

**Changes:** 5 files (+187/-5)

### Files
- `packages/daemon/src/__tests__/circuit-breaker.test.ts`
- `packages/daemon/src/__tests__/kaizen-no-double-insert.test.ts`
- `packages/daemon/src/__tests__/kaizen-scheduler.test.ts`
- `packages/daemon/src/circuit-breaker.ts`
- `packages/daemon/src/scheduler-plugins.ts`

---
Auto-generated by DevPane autonomous agent