### PR TITLE
task-01KKM56P14SZ7ZEHEXJ9CZDD62: recoverOrphanTasksが実行中タスクのworktreeまで削除する問題を修正

### DIFF
--- a/packages/daemon/src/__tests__/orphan-recovery.test.ts
+++ b/packages/daemon/src/__tests__/orphan-recovery.test.ts
@@ -32,7 +32,7 @@ describe("recoverOrphanedTasks", () => {
     const updated = db.prepare(`SELECT status, retry_count FROM tasks WHERE id = ?`).get(task.id) as { status: string; retry_count: number }
     expect(updated.status).toBe("pending")
     expect(updated.retry_count).toBe(1)
-    expect(recovered).toBe(1)
+    expect(recovered).toHaveLength(1)
   })
 
   it("marks orphaned tasks as failed when retry limit exceeded", () => {
@@ -47,7 +47,7 @@ describe("recoverOrphanedTasks", () => {
 
     const updated = db.prepare(`SELECT status FROM tasks WHERE id = ?`).get(task.id) as { status: string }
     expect(updated.status).toBe("failed")
-    expect(recovered).toBe(1)
+    expect(recovered).toHaveLength(1)
   })
 
   it("does not recover tasks that have not timed out yet", () => {
@@ -59,6 +59,6 @@ describe("recoverOrphanedTasks", () => {
     const db = getDb()
     const updated = db.prepare(`SELECT status FROM tasks WHERE id = ?`).get(task.id) as { status: string }
     expect(updated.status).toBe("running")
-    expect(recovered).toBe(0)
+    expect(recovered).toHaveLength(0)
   })
 })

--- a/packages/daemon/src/__tests__/recover-orphan-worktree-scope.test.ts
+++ b/packages/daemon/src/__tests__/recover-orphan-worktree-scope.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsDir = join(__dirname, "..", "..", "src", "migrations")
+
+const mockRemoveWorktree = vi.fn()
+
+vi.mock("../worktree.js", () => ({
+  removeWorktree: (...args: unknown[]) => mockRemoveWorktree(...args),
+  createWorktree: vi.fn(),
+  createPullRequest: vi.fn(),
+  autoMergePr: vi.fn(),
+  pruneWorktrees: vi.fn(),
+  countOpenPrs: vi.fn(() => 0),
+  pullMain: vi.fn(),
+}))
+
+vi.mock("../ws.js", () => ({
+  broadcast: vi.fn(),
+}))
+
+vi.mock("../events.js", () => ({
+  emit: vi.fn(),
+  safeEmit: vi.fn(() => true),
+}))
+
+import { initDb, closeDb, getDb, createTask, startTask } from "../db.js"
+import { config } from "../config.js"
+
+describe("recoverOrphanTasks worktree削除範囲", () => {
+  beforeEach(() => {
+    initDb(":memory:", migrationsDir)
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    closeDb()
+    vi.restoreAllMocks()
+  })
+
+  it("timeout超過タスクのworktreeのみ削除し、実行中タスクのworktreeは削除しない", async () => {
+    const db = getDb()
+
+    // タイムアウト超過タスク（回復対象）
+    const orphan = createTask("orphan-task", "timed out", "pm")
+    startTask(orphan.id, "worker-0")
+    const expiredAt = new Date(Date.now() - config.WORKER_TIMEOUT_MS - 1000).toISOString()
+    db.prepare(`UPDATE tasks SET started_at = ? WHERE id = ?`).run(expiredAt, orphan.id)
+
+    // タイムアウト未超過タスク（実行中、回復対象外）
+    const active = createTask("active-task", "still running", "pm")
+    startTask(active.id, "worker-1")
+    // started_atはstartTaskで現在時刻が設定されるのでそのまま
+
+    // schedulerのrecoverOrphanTasksを実行
+    const { recoverOrphanTasks } = await import("../scheduler.js")
+    recoverOrphanTasks()
+
+    // orphanのworktreeのみ削除されること
+    expect(mockRemoveWorktree).toHaveBeenCalledWith(orphan.id)
+    // activeのworktreeは削除されないこと
+    expect(mockRemoveWorktree).not.toHaveBeenCalledWith(active.id)
+  })
+
+  it("タイムアウト超過タスクが0件の場合、worktree削除は一切行われない", async () => {
+    // タイムアウト未超過のrunningタスクのみ
+    const active = createTask("active-only", "running normally", "pm")
+    startTask(active.id, "worker-0")
+
+    const { recoverOrphanTasks } = await import("../scheduler.js")
+    recoverOrphanTasks()
+
+    expect(mockRemoveWorktree).not.toHaveBeenCalled()
+  })
+
+  it("複数のタイムアウト超過タスクがあっても未超過タスクのworktreeは削除しない", async () => {
+    const db = getDb()
+    const expiredAt = new Date(Date.now() - config.WORKER_TIMEOUT_MS - 1000).toISOString()
+
+    // タイムアウト超過タスク2つ
+    const orphan1 = createTask("orphan-1", "timed out 1", "pm")
+    startTask(orphan1.id, "worker-0")
+    db.prepare(`UPDATE tasks SET started_at = ? WHERE id = ?`).run(expiredAt, orphan1.id)
+
+    const orphan2 = createTask("orphan-2", "timed out 2", "pm")
+    startTask(orphan2.id, "worker-1")
+    db.prepare(`UPDATE tasks SET started_at = ? WHERE id = ?`).run(expiredAt, orphan2.id)
+
+    // タイムアウト未超過タスク1つ
+    const active = createTask("active-task", "still running", "pm")
+    startTask(active.id, "worker-2")
+
+    const { recoverOrphanTasks } = await import("../scheduler.js")
+    recoverOrphanTasks()
+
+    // orphanのworktreeのみ削除
+    expect(mockRemoveWorktree).toHaveBeenCalledWith(orphan1.id)
+    expect(mockRemoveWorktree).toHaveBeenCalledWith(orphan2.id)
+    // activeのworktreeは削除されない
+    expect(mockRemoveWorktree).not.toHaveBeenCalledWith(active.id)
+    // 合計2回のみ呼ばれる
+    expect(mockRemoveWorktree).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/daemon/src/__tests__/scheduler-orphan-recovery.test.ts
+++ b/packages/daemon/src/__tests__/scheduler-orphan-recovery.test.ts
@@ -49,7 +49,7 @@ describe("scheduler orphan recovery (db/tasks.ts unified)", () => {
 
     // recoverOrphanedTasks が返すタスク数に基づき removeWorktree が呼ばれるべき
     // 実装変更後: scheduler が recoverOrphanedTasks の結果に対して removeWorktree を呼ぶ
-    expect(recovered).toBe(1)
+    expect(recovered).toHaveLength(1)
 
     const updated = db.prepare(`SELECT status, retry_count FROM tasks WHERE id = ?`).get(task.id) as {
       status: string
@@ -73,7 +73,7 @@ describe("scheduler orphan recovery (db/tasks.ts unified)", () => {
 
     const recovered = recoverOrphanedTasks(config.WORKER_TIMEOUT_MS, config.MAX_RETRIES)
 
-    expect(recovered).toBe(1)
+    expect(recovered).toHaveLength(1)
     const updated = db.prepare(`SELECT status FROM tasks WHERE id = ?`).get(task.id) as { status: string }
     expect(updated.status).toBe("failed")
   })
@@ -84,7 +84,7 @@ describe("scheduler orphan recovery (db/tasks.ts unified)", () => {
 
     const recovered = recoverOrphanedTasks(config.WORKER_TIMEOUT_MS, config.MAX_RETRIES)
 
-    expect(recovered).toBe(0)
+    expect(recovered).toHaveLength(0)
     const db = getDb()
     const updated = db.prepare(`SELECT status FROM tasks WHERE id = ?`).get(task.id) as { status: string }
     expect(updated.status).toBe("running")
@@ -107,7 +107,7 @@ describe("scheduler orphan recovery (db/tasks.ts unified)", () => {
     })
 
     const recovered = recoverOrphanedTasks(config.WORKER_TIMEOUT_MS, config.MAX_RETRIES)
-    expect(recovered).toBe(3)
+    expect(recovered).toHaveLength(3)
 
     for (const t of tasks) {
       const updated = db.prepare(`SELECT status, retry_count FROM tasks WHERE id = ?`).get(t.id) as {
@@ -138,7 +138,7 @@ describe("scheduler orphan recovery (db/tasks.ts unified)", () => {
     )
 
     const recovered = recoverOrphanedTasks(config.WORKER_TIMEOUT_MS, config.MAX_RETRIES)
-    expect(recovered).toBe(2)
+    expect(recovered).toHaveLength(2)
 
     const retryableRow = db.prepare(`SELECT status, retry_count FROM tasks WHERE id = ?`).get(retryable.id) as {
       status: string

--- a/packages/daemon/src/db/tasks.ts
+++ b/packages/daemon/src/db/tasks.ts
@@ -87,9 +87,9 @@ export function getTasksSince(timestamp: string): Task[] {
 /**
  * Recover orphaned tasks left in 'running' status after daemon restart.
  * Tasks whose started_at exceeds timeoutMs are requeued (if under maxRetries) or failed.
- * Returns the number of recovered tasks.
+ * Returns the IDs of recovered tasks.
  */
-export function recoverOrphanedTasks(timeoutMs: number, maxRetries: number): number {
+export function recoverOrphanedTasks(timeoutMs: number, maxRetries: number): string[] {
   const db = getDb()
   const cutoff = new Date(Date.now() - timeoutMs).toISOString()
   const orphans = db.prepare(
@@ -108,5 +108,5 @@ export function recoverOrphanedTasks(timeoutMs: number, maxRetries: number): num
     }
   }
 
-  return orphans.length
+  return orphans.map(t => t.id)
 }

--- a/packages/daemon/src/scheduler.ts
+++ b/packages/daemon/src/scheduler.ts
@@ -491,19 +491,19 @@ function stopDailyReportTimer(): void {
   }
 }
 
-function recoverOrphanTasks(): void {
+export function recoverOrphanTasks(): void {
   const orphans = getTasksByStatus("running")
   if (orphans.length === 0) return
-  const recovered = recoverOrphanedTasks(config.WORKER_TIMEOUT_MS, config.MAX_RETRIES)
-  if (recovered > 0) {
-    console.log(`[scheduler] recovered ${recovered} orphan tasks (timeout: ${config.WORKER_TIMEOUT_MS}ms, maxRetries: ${config.MAX_RETRIES})`)
-    for (const t of orphans) {
+  const recoveredIds = recoverOrphanedTasks(config.WORKER_TIMEOUT_MS, config.MAX_RETRIES)
+  if (recoveredIds.length > 0) {
+    console.log(`[scheduler] recovered ${recoveredIds.length} orphan tasks (timeout: ${config.WORKER_TIMEOUT_MS}ms, maxRetries: ${config.MAX_RETRIES})`)
+    for (const id of recoveredIds) {
       try {
-        removeWorktree(t.id)
+        removeWorktree(id)
       } catch {
         // ignore cleanup errors during recovery
       }
-      appendLog(t.id, "system", "[recovery] orphan task recovered on daemon restart")
+      appendLog(id, "system", "[recovery] orphan task recovered on daemon restart")
     }
   }
 }


### PR DESCRIPTION
## Summary
Task: `01KKM56P14SZ7ZEHEXJ9CZDD62`

**Changes:** 5 files (+124/-18)

### Files
- `packages/daemon/src/__tests__/orphan-recovery.test.ts`
- `packages/daemon/src/__tests__/recover-orphan-worktree-scope.test.ts`
- `packages/daemon/src/__tests__/scheduler-orphan-recovery.test.ts`
- `packages/daemon/src/db/tasks.ts`
- `packages/daemon/src/scheduler.ts`

---
Auto-generated by DevPane autonomous agent