### PR TITLE
task-01KKM66Y25SZF3EA865S5EY62S: tester.tsのタイムアウトログにtask IDを渡す修正とclaude.tsのSIGKILLフォールバック追加

### DIFF
--- a/packages/daemon/src/__tests__/claude-timeout.test.ts
+++ b/packages/daemon/src/__tests__/claude-timeout.test.ts
@@ -87,4 +87,57 @@ describe("spawnClaude timeout flag", () => {
 
     await expect(promise).resolves.toBe("output data")
   })
+
+  it("sends SIGKILL after 5s if SIGTERM did not kill the process on timeout", async () => {
+    const { spawnClaude } = await import("../claude.js")
+
+    // Override kill to NOT auto-close (simulates SIGTERM being ignored)
+    fakeProc.kill = vi.fn(() => true)
+
+    const promise = spawnClaude(["--print", "hello"], "/tmp", 100)
+
+    // Advance past timeout to trigger SIGTERM
+    vi.advanceTimersByTime(150)
+
+    expect(fakeProc.kill).toHaveBeenCalledWith("SIGTERM")
+
+    // Process is still alive
+    ;(fakeProc as { killed: boolean }).killed = false
+
+    // Advance 5s for SIGKILL fallback
+    vi.advanceTimersByTime(5_000)
+
+    expect(fakeProc.kill).toHaveBeenCalledWith("SIGKILL")
+
+    // Simulate process finally closing
+    fakeProc._emit("close", null, "SIGKILL")
+
+    await expect(promise).rejects.toThrow(/timeout/i)
+  })
+
+  it("does not send SIGKILL if SIGTERM successfully killed the process on timeout", async () => {
+    const { spawnClaude } = await import("../claude.js")
+
+    // Override kill: on SIGTERM, mark killed and emit close after delay
+    fakeProc.kill = vi.fn((signal?: string) => {
+      if (signal === "SIGTERM") {
+        ;(fakeProc as { killed: boolean }).killed = true
+        setTimeout(() => fakeProc._emit("close", null, "SIGTERM"), 0)
+      }
+      return true
+    })
+
+    const promise = spawnClaude(["--print", "hello"], "/tmp", 100)
+
+    // Advance past timeout to trigger SIGTERM
+    vi.advanceTimersByTime(150)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(fakeProc.kill).toHaveBeenCalledWith("SIGTERM")
+
+    await expect(promise).rejects.toThrow(/timeout/i)
+
+    // SIGKILL should never have been called
+    expect(fakeProc.kill).not.toHaveBeenCalledWith("SIGKILL")
+  })
 })

--- a/packages/daemon/src/__tests__/tester-log-taskid.test.ts
+++ b/packages/daemon/src/__tests__/tester-log-taskid.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { EventEmitter } from "node:events"
+import { Readable } from "node:stream"
+import type { ChildProcess } from "node:child_process"
+
+vi.mock("../db.js", () => ({
+  appendLog: vi.fn(),
+}))
+
+vi.mock("../events.js", () => ({
+  emit: vi.fn(),
+}))
+
+vi.mock("../config.js", () => ({
+  config: {
+    WORKER_TIMEOUT_MS: 5_000,
+  },
+}))
+
+function createFakeProc(): ChildProcess & { _emit: (event: string, ...args: unknown[]) => void } {
+  const proc = new EventEmitter() as ChildProcess & { _emit: (event: string, ...args: unknown[]) => void }
+  proc.stdout = new Readable({ read() {} }) as ChildProcess["stdout"]
+  proc.stderr = new Readable({ read() {} }) as ChildProcess["stderr"]
+  proc.pid = 12345
+  proc.killed = false
+  proc.kill = vi.fn(() => true)
+  proc._emit = proc.emit.bind(proc)
+  return proc
+}
+
+let fakeProc: ReturnType<typeof createFakeProc>
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => fakeProc),
+}))
+
+const spec = {
+  tasks: [{ title: "t", description: "d", priority: 1 }],
+  reasoning: "r",
+}
+
+describe("tester timeout appendLog uses task ID", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    fakeProc = createFakeProc()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("passes taskId (not 'tester') as the first argument to appendLog on timeout", async () => {
+    const { appendLog } = await import("../db.js")
+    const { runTester } = await import("../tester.js")
+
+    const taskId = "task-xyz-789"
+    const promise = runTester(spec, "/tmp/worktree", taskId)
+
+    // Advance past idle timeout (WORKER_TIMEOUT_MS + idleCheck interval)
+    vi.advanceTimersByTime(5_000 + 30_000)
+
+    expect(appendLog).toHaveBeenCalledWith(
+      taskId,
+      "tester",
+      expect.stringContaining("timeout"),
+    )
+
+    // First arg must NOT be the hardcoded string 'tester'
+    const calls = vi.mocked(appendLog).mock.calls as string[][]
+    const timeoutCall = calls.find((c: string[]) => String(c[2]).includes("timeout"))
+    expect(timeoutCall).toBeDefined()
+    expect(timeoutCall![0]).toBe(taskId)
+    expect(timeoutCall![0]).not.toBe("tester")
+
+    fakeProc._emit("close", 143)
+    await promise
+  })
+
+  it("falls back to a non-empty identifier when taskId is not provided", async () => {
+    const { appendLog } = await import("../db.js")
+    const { runTester } = await import("../tester.js")
+
+    const promise = runTester(spec, "/tmp/worktree")
+
+    // Advance past idle timeout
+    vi.advanceTimersByTime(5_000 + 30_000)
+
+    expect(appendLog).toHaveBeenCalled()
+    const calls = vi.mocked(appendLog).mock.calls as string[][]
+    const timeoutCall = calls.find((c: string[]) => String(c[2]).includes("timeout"))
+    expect(timeoutCall).toBeDefined()
+    // First arg should be some string (fallback), not undefined
+    expect(typeof timeoutCall![0]).toBe("string")
+    expect(timeoutCall![0].length).toBeGreaterThan(0)
+
+    fakeProc._emit("close", 143)
+    await promise
+  })
+})

--- a/packages/daemon/src/claude.ts
+++ b/packages/daemon/src/claude.ts
@@ -24,14 +24,21 @@ export function spawnClaude(args: string[], cwd: string, timeoutMs?: number): Pr
     proc.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString() })
 
     let timedOut = false
+    let sigkillTimer: ReturnType<typeof setTimeout> | undefined
     const timeout = setTimeout(() => {
       timedOut = true
       proc.kill("SIGTERM")
+      sigkillTimer = setTimeout(() => {
+        if (!proc.killed) {
+          proc.kill("SIGKILL")
+        }
+      }, 5_000)
     }, timeoutMs ?? config.PM_TIMEOUT_MS)
 
     proc.on("close", (code, signal) => {
       activeProcs.delete(proc)
       clearTimeout(timeout)
+      if (sigkillTimer) clearTimeout(sigkillTimer)
       proc.stdout.removeAllListeners("data")
       proc.stderr.removeAllListeners("data")
       let chunk
@@ -51,6 +58,7 @@ export function spawnClaude(args: string[], cwd: string, timeoutMs?: number): Pr
     proc.on("error", (err) => {
       activeProcs.delete(proc)
       clearTimeout(timeout)
+      if (sigkillTimer) clearTimeout(sigkillTimer)
       reject(err)
     })
 

--- a/packages/daemon/src/tester.ts
+++ b/packages/daemon/src/tester.ts
@@ -223,7 +223,7 @@ export function runTester(spec: PmOutput, worktreePath: string, taskId?: string)
     const idleCheck = setInterval(() => {
       if (Date.now() - lastActivity > config.WORKER_TIMEOUT_MS) {
         timedOut = true
-        appendLog("tester", "tester", `[timeout] no activity for ${config.WORKER_TIMEOUT_MS / 1000}s, killing`)
+        appendLog(taskId ?? "tester", "tester", `[timeout] no activity for ${config.WORKER_TIMEOUT_MS / 1000}s, killing`)
         proc.kill("SIGTERM")
         clearInterval(idleCheck)
 


### PR DESCRIPTION
## Summary
Task: `01KKM66Y25SZF3EA865S5EY62S`

**Changes:** 4 files (+162/-1)

### Files
- `packages/daemon/src/__tests__/claude-timeout.test.ts`
- `packages/daemon/src/__tests__/tester-log-taskid.test.ts`
- `packages/daemon/src/claude.ts`
- `packages/daemon/src/tester.ts`

---
Auto-generated by DevPane autonomous agent