### PR TITLE
task-01KKM8TED7MYSTBV2B0JC74KP2: db/stats.tsのgate3_pass_rateクエリでLIMITが集約後に適用され全件集計になるバグの修正

### DIFF
--- a/packages/daemon/src/__tests__/stats-gate-pass-rate.test.ts
+++ b/packages/daemon/src/__tests__/stats-gate-pass-rate.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import { getDb, initDb, closeDb, insertAgentEvent } from "../db.js"
+import { getPipelineStats } from "../db/stats.js"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsDir = join(__dirname, "..", "..", "src", "migrations")
+
+describe("getPipelineStats gate3_pass_rate", () => {
+  beforeEach(() => {
+    initDb(":memory:", migrationsDir)
+  })
+
+  afterEach(() => {
+    closeDb()
+  })
+
+  it("calculates pass rate from recent 20 events only, not all events", () => {
+    // Insert 30 old events: all "go" (pass)
+    for (let i = 0; i < 30; i++) {
+      insertAgentEvent("gate.passed", {
+        type: "gate.passed",
+        taskId: `old-${i}`,
+        gate: "gate3",
+        verdict: "go",
+      } as never)
+    }
+
+    // Make old events have earlier timestamps
+    const db = getDb()
+    const allEvents = db.prepare(
+      `SELECT id FROM agent_events ORDER BY timestamp ASC`,
+    ).all() as { id: string }[]
+
+    for (let i = 0; i < 30; i++) {
+      db.prepare(`UPDATE agent_events SET timestamp = ? WHERE id = ?`).run(
+        `2020-01-01T00:00:${String(i).padStart(2, "0")}.000Z`,
+        allEvents[i].id,
+      )
+    }
+
+    // Insert 20 recent events: 10 pass, 10 reject
+    for (let i = 0; i < 10; i++) {
+      insertAgentEvent("gate.passed", {
+        type: "gate.passed",
+        taskId: `recent-pass-${i}`,
+        gate: "gate3",
+        verdict: "go",
+      } as never)
+    }
+    for (let i = 0; i < 10; i++) {
+      insertAgentEvent("gate.rejected", {
+        type: "gate.rejected",
+        taskId: `recent-fail-${i}`,
+        gate: "gate3",
+        verdict: "kill",
+        reason: "test failure",
+      } as never)
+    }
+
+    const stats = getPipelineStats()
+
+    // If LIMIT 20 is correctly applied BEFORE aggregation,
+    // the 20 most recent events are: 10 pass + 10 reject → rate = 0.5
+    // If LIMIT is applied AFTER aggregation (bug), all 50 events count:
+    // 40 pass + 10 reject → rate = 0.8
+    expect(stats.gate3_pass_rate).toBeCloseTo(0.5)
+  })
+
+  it("works correctly with fewer than 20 events", () => {
+    // 3 pass, 1 reject → rate = 0.75
+    for (let i = 0; i < 3; i++) {
+      insertAgentEvent("gate.passed", {
+        type: "gate.passed",
+        taskId: `p-${i}`,
+        gate: "gate3",
+        verdict: "go",
+      } as never)
+    }
+    insertAgentEvent("gate.rejected", {
+      type: "gate.rejected",
+      taskId: "r-0",
+      gate: "gate3",
+      verdict: "kill",
+      reason: "fail",
+    } as never)
+
+    const stats = getPipelineStats()
+    expect(stats.gate3_pass_rate).toBeCloseTo(0.75)
+  })
+
+  it("returns 0 pass rate when no events exist", () => {
+    const stats = getPipelineStats()
+    expect(stats.gate3_pass_rate).toBe(0)
+  })
+})

--- a/packages/daemon/src/db/stats.ts
+++ b/packages/daemon/src/db/stats.ts
@@ -7,9 +7,11 @@ export function getPipelineStats() {
     SELECT
       COUNT(*) FILTER (WHERE json_extract(payload, '$.verdict') = 'go') AS pass_count,
       COUNT(*) AS total
-    FROM agent_events
-    WHERE type IN ('gate.passed', 'gate.rejected')
-    ORDER BY timestamp DESC LIMIT 20
+    FROM (
+      SELECT * FROM agent_events
+      WHERE type IN ('gate.passed', 'gate.rejected')
+      ORDER BY timestamp DESC LIMIT 20
+    )
   `).get() as { pass_count: number; total: number }
 
   const avgExec = d.prepare(`


### PR DESCRIPTION
## Summary
Task: `01KKM8TED7MYSTBV2B0JC74KP2`

**Changes:** 2 files (+102/-3)

### Files
- `packages/daemon/src/__tests__/stats-gate-pass-rate.test.ts`
- `packages/daemon/src/db/stats.ts`

---
Auto-generated by DevPane autonomous agent