### PR TITLE
task-01KKMCEJDF7EKSNYH7KBHAZVWP: facts.tsのexecFileSyncタイムアウトとテスト失敗を区別できない問題の修正

### DIFF
--- a/packages/daemon/src/__tests__/facts-timeout-classify.test.ts
+++ b/packages/daemon/src/__tests__/facts-timeout-classify.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import { initDb, closeDb } from "../db.js"
+import { runGate3 } from "../gate.js"
+import type { ObservableFacts } from "@devpane/shared"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsDir = join(__dirname, "..", "..", "src", "migrations")
+
+function makeFacts(overrides: Partial<ObservableFacts> = {}): ObservableFacts {
+  return {
+    exit_code: 0,
+    files_changed: ["src/foo.ts"],
+    diff_stats: { additions: 10, deletions: 2 },
+    branch: "devpane/task-test",
+    commit_hash: "abc123",
+    ...overrides,
+  }
+}
+
+describe("facts timeout → classifyRootCause", () => {
+  beforeEach(() => {
+    initDb(":memory:", migrationsDir)
+  })
+
+  afterEach(() => {
+    closeDb()
+  })
+
+  it("timed_out: true のテスト結果は env_issue に分類される", () => {
+    const result = runGate3("timeout-1", makeFacts({
+      test_result: { passed: 0, failed: 1, exit_code: 1, timed_out: true },
+    }))
+    expect(result.verdict).not.toBe("go")
+    expect(result.failure).toBeDefined()
+    expect(result.failure!.root_cause).toBe("env_issue")
+  })
+
+  it("timed_out: true は test_gap より優先される", () => {
+    // failed > 0 でも timed_out があれば env_issue
+    const result = runGate3("timeout-2", makeFacts({
+      test_result: { passed: 3, failed: 2, exit_code: 1, timed_out: true },
+    }))
+    expect(result.failure).toBeDefined()
+    expect(result.failure!.root_cause).toBe("env_issue")
+  })
+
+  it("timed_out: false は通常のテスト失敗として test_gap になる", () => {
+    const result = runGate3("timeout-3", makeFacts({
+      test_result: { passed: 3, failed: 2, exit_code: 1, timed_out: false },
+    }))
+    expect(result.failure).toBeDefined()
+    expect(result.failure!.root_cause).toBe("test_gap")
+  })
+
+  it("timed_out が未設定の場合は従来通り test_gap になる", () => {
+    const result = runGate3("timeout-4", makeFacts({
+      test_result: { passed: 3, failed: 2, exit_code: 1 },
+    }))
+    expect(result.failure).toBeDefined()
+    expect(result.failure!.root_cause).toBe("test_gap")
+  })
+
+  it("timed_out: true かつ lint エラーありでも env_issue が優先される", () => {
+    const result = runGate3("timeout-5", makeFacts({
+      test_result: { passed: 0, failed: 0, exit_code: 1, timed_out: true },
+      lint_result: { errors: 3, exit_code: 1 },
+    }))
+    expect(result.failure).toBeDefined()
+    expect(result.failure!.root_cause).toBe("env_issue")
+  })
+})

--- a/packages/daemon/src/facts.ts
+++ b/packages/daemon/src/facts.ts
@@ -46,7 +46,8 @@ export function collectFacts(
       exit_code: 0,
     }
   } catch (e) {
-    const err = e as { status?: number; stdout?: string; stderr?: string }
+    const err = e as { status?: number; killed?: boolean; signal?: string; stdout?: string; stderr?: string }
+    const timedOut = err.killed === true || err.signal === "SIGTERM"
     if (err.status !== undefined) {
       const output = (err.stdout ?? "") + (err.stderr ?? "")
       const passMatch = output.match(/(\d+)\s+pass/i)
@@ -55,9 +56,10 @@ export function collectFacts(
         passed: passMatch ? Number(passMatch[1]) : 0,
         failed: failMatch ? Number(failMatch[1]) : 0,
         exit_code: err.status ?? 1,
+        ...(timedOut && { timed_out: true }),
       }
     } else {
-      testResult = { passed: 0, failed: 1, exit_code: 1 }
+      testResult = { passed: 0, failed: 1, exit_code: 1, ...(timedOut && { timed_out: true }) }
     }
   }
 

--- a/packages/daemon/src/gate.ts
+++ b/packages/daemon/src/gate.ts
@@ -78,6 +78,7 @@ export function runGate3(taskId: string, facts: ObservableFacts): Gate3Result {
 }
 
 function classifyRootCause(facts: ObservableFacts, reasons: string[]): RootCauseType {
+  if (facts.test_result?.timed_out) return "env_issue"
   if (facts.test_result?.failed && facts.test_result.failed > 0) return "test_gap"
   if (facts.lint_result?.errors && facts.lint_result.errors > 0) return "scope_creep"
   const diffSize = facts.diff_stats.additions + facts.diff_stats.deletions

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -33,6 +33,7 @@ export type ObservableFacts = {
     passed: number
     failed: number
     exit_code: number
+    timed_out?: boolean
   }
   lint_result?: {
     errors: number


### PR DESCRIPTION
## Summary
Task: `01KKMCEJDF7EKSNYH7KBHAZVWP`

**Changes:** 4 files (+79/-2)

### Files
- `packages/daemon/src/__tests__/facts-timeout-classify.test.ts`
- `packages/daemon/src/facts.ts`
- `packages/daemon/src/gate.ts`
- `packages/shared/src/types.ts`

---
Auto-generated by DevPane autonomous agent