### PR TITLE
task-01KKMD80PMRK93NQNZR6BPEKD9: facts.tsのlintチェックでJS例外とプロセス終了を区別せずerrors:1を設定する問題の修正

### DIFF
--- a/packages/daemon/src/__tests__/facts-lint-spawn-error.test.ts
+++ b/packages/daemon/src/__tests__/facts-lint-spawn-error.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("../db.js", () => ({
+  appendLog: vi.fn(),
+}))
+
+vi.mock("../worktree.js", () => ({
+  commitWorktree: vi.fn(() => "abc123def"),
+  getWorktreeDiff: vi.fn(() => ({
+    filesChanged: ["src/index.ts"],
+    additions: 5,
+    deletions: 1,
+  })),
+}))
+
+// execFileSyncがlintコマンド時にstatusプロパティなしのErrorをthrow
+// → pnpmコマンド自体のspawn失敗（ENOENT等）を模擬
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn((cmd: string, args: string[]) => {
+    if (cmd === "pnpm" && args.includes("lint")) {
+      // statusプロパティなし = JS例外（spawn失敗、ENOENT等）
+      throw new Error("spawn ENOENT: pnpm not found")
+    }
+    if (cmd === "pnpm" && args[0] === "test") {
+      return "Tests: 3 passed, 0 failed"
+    }
+    return ""
+  }),
+}))
+
+const { collectFacts } = await import("../facts.js")
+
+describe("collectFacts: lintコマンドのspawn失敗（JS例外）", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("statusプロパティなしのErrorではlint_resultがundefinedになる", () => {
+    const facts = collectFacts("task-lint-spawn", "Test task", "/tmp/worktree", 0)
+
+    // spawn失敗はlintエラーではないため、lint_resultは設定されるべきでない
+    expect(facts.lint_result).toBeUndefined()
+  })
+
+  it("spawn失敗時にlint errors: N としてgate3に渡らない", () => {
+    const facts = collectFacts("task-lint-spawn-2", "Test task", "/tmp/worktree", 0)
+
+    // lint_resultが存在する場合でもerrors: 0であるべき
+    if (facts.lint_result) {
+      expect(facts.lint_result.errors).toBe(0)
+    }
+  })
+
+  it("spawn失敗してもテスト結果は正常に取得される", () => {
+    const facts = collectFacts("task-lint-spawn-3", "Test task", "/tmp/worktree", 0)
+
+    expect(facts.test_result).toEqual({
+      passed: 3,
+      failed: 0,
+      exit_code: 0,
+    })
+  })
+})

--- a/packages/daemon/src/__tests__/facts.test.ts
+++ b/packages/daemon/src/__tests__/facts.test.ts
@@ -82,7 +82,7 @@ describe("collectFacts", () => {
     expect(facts.test_result!.exit_code).toBe(1)
   })
 
-  it("returns default lintResult when lint throws unexpected error (no status)", async () => {
+  it("returns undefined lintResult when lint throws unexpected error (no status)", async () => {
     const cp = await import("node:child_process")
     const mock = vi.mocked(cp.execFileSync)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -94,8 +94,6 @@ describe("collectFacts", () => {
     }) as any)
 
     const facts = collectFacts("task-006", "Lint crash", "/tmp/worktree", 0)
-    expect(facts.lint_result).toBeDefined()
-    expect(facts.lint_result!.errors).toBeGreaterThanOrEqual(1)
-    expect(facts.lint_result!.exit_code).toBe(1)
+    expect(facts.lint_result).toBeUndefined()
   })
 })

--- a/packages/daemon/src/facts.ts
+++ b/packages/daemon/src/facts.ts
@@ -84,9 +84,8 @@ export function collectFacts(
         errors: errorMatch ? Number(errorMatch[1]) : 1,
         exit_code: err.status ?? 1,
       }
-    } else {
-      lintResult = { errors: 1, exit_code: 1 }
     }
+    // else: statusプロパティなし = spawn失敗（ENOENT等）→ lintResultはundefinedのまま
   }
 
   return {


### PR DESCRIPTION
## Summary
Task: `01KKMD80PMRK93NQNZR6BPEKD9`

**Changes:** 3 files (+66/-6)

### Files
- `packages/daemon/src/__tests__/facts-lint-spawn-error.test.ts`
- `packages/daemon/src/__tests__/facts.test.ts`
- `packages/daemon/src/facts.ts`

---
Auto-generated by DevPane autonomous agent