### PR TITLE
task-01KKPKG797B69Q940Y1WTMZXGR: worktree.tsのpruneWorktreesでgit branch出力の'* 'プレフィックスが除去されずブランチ削除が失敗する修正

### DIFF
--- a/packages/daemon/src/__tests__/prune-branch-prefix.test.ts
+++ b/packages/daemon/src/__tests__/prune-branch-prefix.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("../config.js", () => ({
+  config: { PROJECT_ROOT: "/fake/project", BRANCH_PREFIX: "devpane" },
+}))
+
+vi.mock("node:fs", () => ({
+  existsSync: () => true,
+  readdirSync: () => [],
+}))
+
+const execFileSyncMock = vi.fn()
+vi.mock("node:child_process", () => ({
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+}))
+
+const { pruneWorktrees } = await import("../worktree.js")
+
+function setupMock(branchListOutput: string) {
+  execFileSyncMock.mockImplementation((cmd: string, args: string[]) => {
+    if (cmd === "git" && args[0] === "worktree" && args[1] === "prune") return ""
+    if (cmd === "git" && args[0] === "branch" && args[1] === "--list") {
+      return branchListOutput
+    }
+    if (cmd === "gh" && args[0] === "pr" && args[1] === "list") return "[]"
+    if (cmd === "git" && args[0] === "branch" && args[1] === "-D") return ""
+    return ""
+  })
+}
+
+function getDeletedBranches(): string[] {
+  return execFileSyncMock.mock.calls
+    .filter((c: unknown[]) => c[0] === "git" && (c[1] as string[])[0] === "branch" && (c[1] as string[])[1] === "-D")
+    .map((c: unknown[]) => (c[1] as string[])[2])
+}
+
+describe("pruneWorktrees strips git branch prefix markers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("strips '* ' prefix from current branch", () => {
+    setupMock("* devpane/task-current\n  devpane/task-normal\n")
+
+    pruneWorktrees()
+
+    const deleted = getDeletedBranches()
+    expect(deleted).toContain("devpane/task-current")
+    expect(deleted).toContain("devpane/task-normal")
+    expect(deleted).not.toContain("* devpane/task-current")
+  })
+
+  it("strips '+ ' prefix from worktree-checked-out branch", () => {
+    setupMock("+ devpane/task-wt\n  devpane/task-normal\n")
+
+    pruneWorktrees()
+
+    const deleted = getDeletedBranches()
+    expect(deleted).toContain("devpane/task-wt")
+    expect(deleted).not.toContain("+ devpane/task-wt")
+  })
+
+  it("handles mixed prefixes correctly", () => {
+    setupMock("* devpane/task-current\n+ devpane/task-wt\n  devpane/task-plain\n")
+
+    pruneWorktrees()
+
+    const deleted = getDeletedBranches()
+    expect(deleted).toContain("devpane/task-current")
+    expect(deleted).toContain("devpane/task-wt")
+    expect(deleted).toContain("devpane/task-plain")
+  })
+
+  it("does not pass prefix markers to git branch -D", () => {
+    setupMock("* devpane/task-star\n+ devpane/task-plus\n")
+
+    pruneWorktrees()
+
+    const deleted = getDeletedBranches()
+    for (const branch of deleted) {
+      expect(branch).not.toMatch(/^[*+]/)
+    }
+  })
+})

--- a/packages/daemon/src/worktree.ts
+++ b/packages/daemon/src/worktree.ts
@@ -153,7 +153,7 @@ export function pruneWorktrees(): void {
 
   // devpane/ プレフィックスの孤立ブランチを掃除
   try {
-    const branches = git("branch", "--list", `${config.BRANCH_PREFIX}/*`).split("\n").map(b => b.trim()).filter(Boolean)
+    const branches = git("branch", "--list", `${config.BRANCH_PREFIX}/*`).split("\n").map(b => b.replace(/^[*+]\s+/, "").trim()).filter(Boolean)
     for (const branch of branches) {
       if (hasOpenPr(branch)) {
         console.log(`[worktree] skipping branch with open PR: ${branch}`)


### PR DESCRIPTION
## Summary
Task: `01KKPKG797B69Q940Y1WTMZXGR`

**Changes:** 2 files (+85/-1)

### Files
- `packages/daemon/src/__tests__/prune-branch-prefix.test.ts`
- `packages/daemon/src/worktree.ts`

---
Auto-generated by DevPane autonomous agent