### PR TITLE
task-01KKTDTAVK26JB5DYDQZA6M9T6: morning-report.tsの送信失敗をevent systemに記録する

### DIFF
--- a/packages/daemon/src/__tests__/morning-report-fail.test.ts
+++ b/packages/daemon/src/__tests__/morning-report-fail.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsDir = join(__dirname, "..", "..", "src", "migrations")
+
+const mockEmit = vi.fn()
+vi.mock("../events.js", () => ({
+  emit: (...args: unknown[]) => mockEmit(...args),
+  safeEmit: vi.fn(() => true),
+}))
+
+const mockSendReport = vi.fn()
+vi.mock("../notifier-factory.js", () => ({
+  getNotifier: () => ({
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    sendReport: mockSendReport,
+    notify: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+vi.mock("../pr-agent.js", () => ({
+  fetchOpenPrs: vi.fn().mockReturnValue([]),
+  assessRisk: vi.fn(),
+}))
+
+describe("morning-report failure → event emission", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const { initDb } = await import("../db.js")
+    initDb(":memory:", migrationsDir)
+  })
+
+  afterEach(async () => {
+    const { closeDb } = await import("../db.js")
+    closeDb()
+  })
+
+  it("sendMorningReport が失敗した場合エラーを再throwする", async () => {
+    mockSendReport.mockRejectedValueOnce(new Error("Discord webhook down"))
+
+    const { sendMorningReport } = await import("../morning-report.js")
+    const since = new Date(Date.now() - 3600000).toISOString()
+
+    await expect(sendMorningReport(since)).rejects.toThrow("Discord webhook down")
+  })
+
+  it("morning_report.failed イベントが AgentEventSchema に含まれる", async () => {
+    // 実装で AgentEventSchema に morning_report.failed を追加する必要がある
+    const { AgentEventSchema } = await import("@devpane/shared/schemas")
+
+    const event = {
+      type: "morning_report.failed",
+      error: "Slack API timeout",
+    }
+
+    const result = AgentEventSchema.safeParse(event)
+    expect(result.success).toBe(true)
+  })
+
+  it("sendReport 失敗時に morning_report.failed イベントが emit される", async () => {
+    mockSendReport.mockRejectedValueOnce(new Error("Network error"))
+
+    const { sendMorningReport } = await import("../morning-report.js")
+    const since = new Date(Date.now() - 3600000).toISOString()
+
+    // sendMorningReport を呼び、失敗をcatchする（scheduler.tsのcatch節と同等）
+    try {
+      await sendMorningReport(since)
+    } catch {
+      // 失敗は期待通り
+    }
+
+    // 実装後: scheduler.ts の catch 節で emit({ type: 'morning_report.failed', ... }) が呼ばれる
+    // ここでは emit が morning_report.failed で呼ばれたことを検証
+    expect(mockEmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "morning_report.failed",
+        error: expect.any(String),
+      }),
+    )
+  })
+})

--- a/packages/daemon/src/morning-report.ts
+++ b/packages/daemon/src/morning-report.ts
@@ -3,6 +3,7 @@ import { getPipelineStats } from "./db/stats.js"
 import { fetchOpenPrs, assessRisk, type PrReport } from "./pr-agent.js"
 import { getNotifier } from "./notifier-factory.js"
 import { traceTask, type PipelineTrace } from "./pipeline-trace.js"
+import { emit } from "./events.js"
 import type { ReportPayload, ReportSection } from "./notifier.js"
 import type { Task } from "@devpane/shared"
 
@@ -102,5 +103,11 @@ export async function sendMorningReport(shiftStartIso: string): Promise<void> {
   const report = formatReport(summary)
 
   console.log(`[morning-report] sending: ${summary.completed.length} done, ${summary.failed.length} failed, $${summary.totalCost.toFixed(2)}`)
-  await getNotifier().sendReport(report)
+  try {
+    await getNotifier().sendReport(report)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    emit({ type: "morning_report.failed", error: msg })
+    throw err
+  }
 }

--- a/packages/daemon/src/scheduler.ts
+++ b/packages/daemon/src/scheduler.ts
@@ -490,7 +490,9 @@ function startDailyReportTimer(): void {
     if (wasWithinHours && !withinHours && shiftStartIso) {
       console.log("[scheduler] shift ended, sending morning report")
       sendMorningReport(shiftStartIso).catch((err) => {
-        console.error(`[scheduler] morning report failed: ${err instanceof Error ? err.message : String(err)}`)
+        const msg = err instanceof Error ? err.message : String(err)
+        console.error(`[scheduler] morning report failed: ${msg}`)
+        emit({ type: "morning_report.failed", error: msg })
       })
       shiftStartIso = null
     }

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -98,6 +98,7 @@ export const AgentEventSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("spc.alert"), metric: z.string(), value: z.number(), ucl: z.number() }),
   z.object({ type: z.literal("gate.llm_fallback"), taskId: z.string(), gate: PipelineStage, error: z.string() }),
   z.object({ type: z.literal("scheduler.outside_hours") }),
+  z.object({ type: z.literal("morning_report.failed"), error: z.string() }),
 ])
 
 // --- Type exports ---


### PR DESCRIPTION
## Summary
Task: `01KKTDTAVK26JB5DYDQZA6M9T6`

**Changes:** 4 files (+96/-2)

### Files
- `packages/daemon/src/__tests__/morning-report-fail.test.ts`
- `packages/daemon/src/morning-report.ts`
- `packages/daemon/src/scheduler.ts`
- `packages/shared/src/schemas.ts`

---
Auto-generated by DevPane autonomous agent