### PR TITLE
task-01KKTEZ0WXZPHEEGH8TWYVSYB6: facts.tsのビルド失敗時にテスト・lint実行をスキップするガード追加

### DIFF
--- a/packages/daemon/src/__tests__/facts-skip-on-build-fail.test.ts
+++ b/packages/daemon/src/__tests__/facts-skip-on-build-fail.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const mockExecFileSync = vi.fn()
+const mockAppendLog = vi.fn()
+
+vi.mock("node:child_process", () => ({
+  execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
+}))
+
+vi.mock("../db.js", () => ({
+  appendLog: (...args: unknown[]) => mockAppendLog(...args),
+}))
+
+vi.mock("../worktree.js", () => ({
+  commitWorktree: vi.fn(() => "abc123def"),
+  getWorktreeDiff: vi.fn(() => ({
+    filesChanged: ["src/index.ts"],
+    additions: 5,
+    deletions: 1,
+  })),
+}))
+
+const { collectFacts } = await import("../facts.js")
+
+describe("collectFacts: ビルド失敗時にテスト・lintをスキップ", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("ビルド失敗時、テストコマンドが呼ばれない", () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "pnpm" && args[0] === "build") {
+        throw Object.assign(new Error("build failed"), { status: 1, stderr: "type error" })
+      }
+      return ""
+    })
+
+    collectFacts("task-skip-1", "Fail build", "/tmp/wt", 0)
+
+    const calls = mockExecFileSync.mock.calls
+    const testCalls = calls.filter(
+      ([cmd, args]: [string, string[]]) => cmd === "pnpm" && args[0] === "test",
+    )
+    expect(testCalls).toHaveLength(0)
+  })
+
+  it("ビルド失敗時、lintコマンドが呼ばれない", () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "pnpm" && args[0] === "build") {
+        throw Object.assign(new Error("build failed"), { status: 1, stderr: "type error" })
+      }
+      return ""
+    })
+
+    collectFacts("task-skip-2", "Fail build", "/tmp/wt", 0)
+
+    const calls = mockExecFileSync.mock.calls
+    const lintCalls = calls.filter(
+      ([cmd, args]: [string, string[]]) => cmd === "pnpm" && args.includes("lint"),
+    )
+    expect(lintCalls).toHaveLength(0)
+  })
+
+  it("ビルド失敗時、test_resultのデフォルト値が設定される", () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "pnpm" && args[0] === "build") {
+        throw Object.assign(new Error("build failed"), { status: 1, stderr: "type error" })
+      }
+      return ""
+    })
+
+    const facts = collectFacts("task-skip-3", "Fail build", "/tmp/wt", 0)
+
+    expect(facts.test_result).toEqual({
+      passed: 0,
+      failed: 0,
+      exit_code: 0,
+    })
+  })
+
+  it("ビルド失敗時、lint_resultのデフォルト値が設定される", () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "pnpm" && args[0] === "build") {
+        throw Object.assign(new Error("build failed"), { status: 1, stderr: "type error" })
+      }
+      return ""
+    })
+
+    const facts = collectFacts("task-skip-4", "Fail build", "/tmp/wt", 0)
+
+    expect(facts.lint_result).toEqual({
+      errors: 0,
+      exit_code: 0,
+    })
+  })
+
+  it("ビルド失敗時、factsにbuild_failed: trueが含まれる", () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "pnpm" && args[0] === "build") {
+        throw Object.assign(new Error("build failed"), { status: 1, stderr: "type error" })
+      }
+      return ""
+    })
+
+    const facts = collectFacts("task-skip-5", "Fail build", "/tmp/wt", 0)
+
+    expect(facts.build_failed).toBe(true)
+  })
+
+  it("ビルド成功時、テスト・lintが通常通り実行される", () => {
+    mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "pnpm" && args[0] === "test") {
+        return "Tests: 3 passed, 0 failed"
+      }
+      if (cmd === "pnpm" && args.includes("lint")) {
+        return "Done. 0 errors found."
+      }
+      return ""
+    })
+
+    const facts = collectFacts("task-ok-1", "Success build", "/tmp/wt", 0)
+
+    const calls = mockExecFileSync.mock.calls
+    const testCalls = calls.filter(
+      ([cmd, args]: [string, string[]]) => cmd === "pnpm" && args[0] === "test",
+    )
+    const lintCalls = calls.filter(
+      ([cmd, args]: [string, string[]]) => cmd === "pnpm" && args.includes("lint"),
+    )
+    expect(testCalls).toHaveLength(1)
+    expect(lintCalls).toHaveLength(1)
+    expect(facts.test_result?.passed).toBe(3)
+    expect(facts.lint_result?.errors).toBe(0)
+  })
+
+  it("ビルド成功時、build_failedがfalseまたは未設定", () => {
+    mockExecFileSync.mockReturnValue("")
+
+    const facts = collectFacts("task-ok-2", "Success build", "/tmp/wt", 0)
+
+    expect(facts.build_failed).toBeFalsy()
+  })
+})

--- a/packages/daemon/src/facts.ts
+++ b/packages/daemon/src/facts.ts
@@ -32,66 +32,74 @@ export function collectFacts(
     appendLog(taskId, "build", `[error] ${config.BUILD_CMD} failed: ${detail}`)
   }
 
-  // Run tests if available
+  // Run tests if available (skip when build failed)
   let testResult: ObservableFacts["test_result"]
-  try {
-    const test = parseCmd(config.TEST_CMD)
-    const result = execFileSync(test.bin, test.args, {
-      cwd: worktreePath,
-      encoding: "utf-8",
-      timeout: 120000,
-    })
-    const passMatch = result.match(/(\d+)\s+pass/i)
-    const failMatch = result.match(/(\d+)\s+fail/i)
-    testResult = {
-      passed: passMatch ? Number(passMatch[1]) : 0,
-      failed: failMatch ? Number(failMatch[1]) : 0,
-      exit_code: 0,
-    }
-  } catch (e) {
-    const err = e as { status?: number; killed?: boolean; signal?: string; stdout?: string; stderr?: string }
-    const timedOut = err.killed === true || err.signal === "SIGTERM"
-    if (err.status !== undefined) {
-      const output = (err.stdout ?? "") + (err.stderr ?? "")
-      const passMatch = output.match(/(\d+)\s+pass/i)
-      const failMatch = output.match(/(\d+)\s+fail/i)
+  if (buildFailed) {
+    testResult = { passed: 0, failed: 0, exit_code: 0 }
+  } else {
+    try {
+      const test = parseCmd(config.TEST_CMD)
+      const result = execFileSync(test.bin, test.args, {
+        cwd: worktreePath,
+        encoding: "utf-8",
+        timeout: 120000,
+      })
+      const passMatch = result.match(/(\d+)\s+pass/i)
+      const failMatch = result.match(/(\d+)\s+fail/i)
       testResult = {
         passed: passMatch ? Number(passMatch[1]) : 0,
         failed: failMatch ? Number(failMatch[1]) : 0,
-        exit_code: err.status ?? 1,
-        ...(timedOut && { timed_out: true }),
+        exit_code: 0,
       }
-    } else {
-      testResult = { passed: 0, failed: 1, exit_code: 1, ...(timedOut && { timed_out: true }) }
+    } catch (e) {
+      const err = e as { status?: number; killed?: boolean; signal?: string; stdout?: string; stderr?: string }
+      const timedOut = err.killed === true || err.signal === "SIGTERM"
+      if (err.status !== undefined) {
+        const output = (err.stdout ?? "") + (err.stderr ?? "")
+        const passMatch = output.match(/(\d+)\s+pass/i)
+        const failMatch = output.match(/(\d+)\s+fail/i)
+        testResult = {
+          passed: passMatch ? Number(passMatch[1]) : 0,
+          failed: failMatch ? Number(failMatch[1]) : 0,
+          exit_code: err.status ?? 1,
+          ...(timedOut && { timed_out: true }),
+        }
+      } else {
+        testResult = { passed: 0, failed: 1, exit_code: 1, ...(timedOut && { timed_out: true }) }
+      }
     }
   }
 
-  // Run lint if available
+  // Run lint if available (skip when build failed)
   let lintResult: ObservableFacts["lint_result"]
-  try {
-    const lint = parseCmd(config.LINT_CMD)
-    const result = execFileSync(lint.bin, lint.args, {
-      cwd: worktreePath,
-      encoding: "utf-8",
-      timeout: 60000,
-    })
-    // Count error lines from typical lint output
-    const errorMatch = result.match(/(\d+)\s+errors?/i)
-    lintResult = {
-      errors: errorMatch ? Number(errorMatch[1]) : 0,
-      exit_code: 0,
-    }
-  } catch (e) {
-    const err = e as { status?: number; stdout?: string; stderr?: string }
-    if (err.status !== undefined) {
-      const output = (err.stdout ?? "") + (err.stderr ?? "")
-      const errorMatch = output.match(/(\d+)\s+errors?/i)
+  if (buildFailed) {
+    lintResult = { errors: 0, exit_code: 0 }
+  } else {
+    try {
+      const lint = parseCmd(config.LINT_CMD)
+      const result = execFileSync(lint.bin, lint.args, {
+        cwd: worktreePath,
+        encoding: "utf-8",
+        timeout: 60000,
+      })
+      // Count error lines from typical lint output
+      const errorMatch = result.match(/(\d+)\s+errors?/i)
       lintResult = {
-        errors: errorMatch ? Number(errorMatch[1]) : 1,
-        exit_code: err.status ?? 1,
+        errors: errorMatch ? Number(errorMatch[1]) : 0,
+        exit_code: 0,
       }
+    } catch (e) {
+      const err = e as { status?: number; stdout?: string; stderr?: string }
+      if (err.status !== undefined) {
+        const output = (err.stdout ?? "") + (err.stderr ?? "")
+        const errorMatch = output.match(/(\d+)\s+errors?/i)
+        lintResult = {
+          errors: errorMatch ? Number(errorMatch[1]) : 1,
+          exit_code: err.status ?? 1,
+        }
+      }
+      // else: statusプロパティなし = spawn失敗（ENOENT等）→ lintResultはundefinedのまま
     }
-    // else: statusプロパティなし = spawn失敗（ENOENT等）→ lintResultはundefinedのまま
   }
 
   return {
@@ -100,6 +108,7 @@ export function collectFacts(
     diff_stats: { additions, deletions },
     test_result: testResult,
     lint_result: lintResult,
+    ...(buildFailed && { build_failed: true }),
     branch: `${config.BRANCH_PREFIX}/task-${taskId}`,
     commit_hash: commitHash,
   }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -39,6 +39,7 @@ export type ObservableFacts = {
     errors: number
     exit_code: number
   }
+  build_failed?: boolean
   branch: string
   commit_hash?: string
 }


### PR DESCRIPTION
## Summary
Task: `01KKTEZ0WXZPHEEGH8TWYVSYB6`

**Changes:** 3 files (+201/-48)

### Files
- `packages/daemon/src/__tests__/facts-skip-on-build-fail.test.ts`
- `packages/daemon/src/facts.ts`
- `packages/shared/src/types.ts`

---
Auto-generated by DevPane autonomous agent