### PR TITLE
task-01KKTGMYPFSSS5VX4C22CDDD28: scheduler.tsのgate3 passパスでtask.startedイベントが重複発火する修正

### DIFF
--- a/packages/daemon/src/__tests__/gate3-pass-no-started.test.ts
+++ b/packages/daemon/src/__tests__/gate3-pass-no-started.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import type { Task, ObservableFacts } from "@devpane/shared"
+import type { AgentEvent } from "@devpane/shared/schemas"
+import type { Gate1Result } from "../gate1.js"
+import type { Gate2Result } from "../gate2.js"
+import type { Gate3Result } from "../gate.js"
+import type { TesterResult } from "../tester.js"
+import type { WorkerResult } from "../worker.js"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsDir = join(__dirname, "..", "..", "src", "migrations")
+
+// --- Mocks (emit is NOT mocked — uses real DB insertion) ---
+
+vi.mock("../ws.js", () => ({
+  broadcast: vi.fn(),
+}))
+
+vi.mock("../discord.js", () => ({
+  notify: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock("../scheduler-plugins.js", () => ({
+  EFFECT_MEASURE_THRESHOLD: 10,
+  checkEffectMeasurement: vi.fn(),
+  resetEffectMeasureCounter: vi.fn(),
+  setEffectMeasureCounter: vi.fn(),
+  getEffectMeasureCounter: vi.fn(() => 0),
+  getKaizenCounter: vi.fn(() => 0),
+  KAIZEN_THRESHOLD: 10,
+  checkKaizenAnalysis: vi.fn(),
+  resetKaizenCounter: vi.fn(),
+  setKaizenCounter: vi.fn(),
+}))
+
+vi.mock("../scheduler-hooks.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../scheduler-hooks.js")>()
+  return {
+    ...original,
+    runHooks: vi.fn(),
+  }
+})
+
+const mockRunGate1 = vi.fn<(task: Task) => Promise<Gate1Result>>()
+vi.mock("../gate1.js", () => ({
+  runGate1: (...args: [Task]) => mockRunGate1(...args),
+}))
+
+const mockRunGate2 = vi.fn<() => Gate2Result>()
+vi.mock("../gate2.js", () => ({
+  runGate2: () => mockRunGate2(),
+}))
+
+const mockRunGate3 = vi.fn<(taskId: string, facts: ObservableFacts) => Gate3Result>()
+vi.mock("../gate.js", () => ({
+  runGate3: (...args: [string, ObservableFacts]) => mockRunGate3(...args),
+}))
+
+const mockRunTester = vi.fn<() => Promise<TesterResult>>()
+vi.mock("../tester.js", () => ({
+  runTester: () => mockRunTester(),
+  buildTesterPrompt: vi.fn(() => "prompt"),
+}))
+
+const mockRunWorker = vi.fn<() => Promise<WorkerResult>>()
+vi.mock("../worker.js", () => ({
+  runWorker: () => mockRunWorker(),
+  killAllWorkers: vi.fn(),
+}))
+
+const mockCollectFacts = vi.fn<() => ObservableFacts>()
+vi.mock("../facts.js", () => ({
+  collectFacts: () => mockCollectFacts(),
+}))
+
+vi.mock("../worktree.js", () => ({
+  createWorktree: vi.fn(() => "/tmp/worktree"),
+  removeWorktree: vi.fn(),
+  createPullRequest: vi.fn(() => null),
+  autoMergePr: vi.fn(() => false),
+  pullMain: vi.fn(),
+  pruneWorktrees: vi.fn(),
+  countOpenPrs: vi.fn(() => 0),
+}))
+
+vi.mock("../circuit-breaker.js", () => ({
+  circuitBreaker: {
+    canProceed: vi.fn(() => true),
+    recordSuccess: vi.fn(),
+    recordFailure: vi.fn(),
+    getState: vi.fn(() => "closed"),
+    getBackoffSec: vi.fn(() => 1),
+  },
+}))
+
+vi.mock("../pr-agent.js", () => ({
+  runPrAgent: vi.fn(),
+}))
+
+// Real DB + real events.js (no mock)
+import { initDb, closeDb, createTask } from "../db.js"
+import { getEventsByTaskId } from "../db/events.js"
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return createTask(
+    overrides.title ?? "gate3 pass event test task",
+    overrides.description ?? "a sufficiently long task description for gate1 validation",
+    "human",
+    overrides.priority ?? 50,
+  )
+}
+
+function goodFacts(overrides: Partial<ObservableFacts> = {}): ObservableFacts {
+  return {
+    exit_code: 0,
+    files_changed: ["src/foo.ts"],
+    diff_stats: { additions: 10, deletions: 2 },
+    test_result: { passed: 5, failed: 0, exit_code: 0 },
+    lint_result: { errors: 0, exit_code: 0 },
+    branch: "devpane/task-test",
+    commit_hash: "abc123",
+    ...overrides,
+  }
+}
+
+function goodWorkerResult(): WorkerResult {
+  return {
+    exit_code: 0,
+    result_text: "done",
+    cost_usd: 0.05,
+    num_turns: 3,
+    duration_ms: 10000,
+  }
+}
+
+describe("gate3 pass時にtask.startedを重複発火しない", () => {
+  beforeEach(() => {
+    initDb(":memory:", migrationsDir)
+    vi.clearAllMocks()
+
+    // Default: all gates pass
+    mockRunGate1.mockResolvedValue({ verdict: "go", reasons: [] })
+    mockRunTester.mockResolvedValue({ testFiles: ["src/__tests__/foo.test.ts"], exit_code: 0, timedOut: false })
+    mockRunGate2.mockReturnValue({ verdict: "go", reasons: [] })
+    mockRunWorker.mockResolvedValue(goodWorkerResult())
+    mockCollectFacts.mockReturnValue(goodFacts())
+    mockRunGate3.mockReturnValue({ verdict: "go", reasons: [] })
+  })
+
+  afterEach(() => {
+    closeDb()
+  })
+
+  it("gate3 pass後にtask.startedイベントが発火されない", async () => {
+    const { executeTask } = await import("../scheduler.js")
+    const task = makeTask()
+
+    await executeTask(task)
+
+    // gate3 passパスでtask.startedを発火してはならない
+    // startTask()はDB状態を更新するだけでイベントを発火しないため、
+    // 371行目のemit削除後はtask.startedイベントが0件になるべき
+    const taskEvents = getEventsByTaskId(task.id)
+    const taskStartedEvents = taskEvents.filter((e) => e.type === "task.started")
+    expect(taskStartedEvents).toHaveLength(0)
+  })
+
+  it("gate3 pass時にgate.passedイベントは正しく記録される", async () => {
+    const { executeTask } = await import("../scheduler.js")
+    const task = makeTask()
+
+    await executeTask(task)
+
+    const taskEvents = getEventsByTaskId(task.id)
+    const gatePassed = taskEvents.filter(
+      (e) => e.type === "gate.passed" && "gate" in e && e.gate === "gate3",
+    ) as Array<Extract<AgentEvent, { type: "gate.passed" }>>
+    expect(gatePassed).toHaveLength(1)
+    expect(gatePassed[0].taskId).toBe(task.id)
+  })
+})

--- a/packages/daemon/src/__tests__/pipeline-e2e.test.ts
+++ b/packages/daemon/src/__tests__/pipeline-e2e.test.ts
@@ -191,7 +191,6 @@ describe("pipeline e2e: executeTask", () => {
     // イベント検証
     const types = emittedEvents.map(e => e.type)
     expect(types).toContain("gate.passed")
-    expect(types).toContain("task.started")
     expect(types).toContain("task.completed")
     expect(types).toContain("pr.created")
   })

--- a/packages/daemon/src/scheduler.ts
+++ b/packages/daemon/src/scheduler.ts
@@ -368,7 +368,6 @@ export async function executeTask(task: Task): Promise<void> {
       }
     } else {
       // Gate 3 passed → PR作成
-      emit({ type: "task.started", taskId: task.id, workerId })
       emit({ type: "gate.passed", taskId: task.id, gate: "gate3" })
       updateTaskCost(task.id, result.cost_usd, result.num_turns)
       const diffSize = facts.diff_stats.additions + facts.diff_stats.deletions


### PR DESCRIPTION
## Summary
Task: `01KKTGMYPFSSS5VX4C22CDDD28`

**Changes:** 3 files (+183/-2)

### Files
- `packages/daemon/src/__tests__/gate3-pass-no-started.test.ts`
- `packages/daemon/src/__tests__/pipeline-e2e.test.ts`
- `packages/daemon/src/scheduler.ts`

---
Auto-generated by DevPane autonomous agent