### PR TITLE
task-01KKTGMYPE580WNY22M82HHHK1: api/events.tsのlimitクエリパラメータがNaN時にSQLiteクエリが不正になる問題の修正

### DIFF
--- a/packages/daemon/src/__tests__/events-api-limit.test.ts
+++ b/packages/daemon/src/__tests__/events-api-limit.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("../events.js", () => ({
+  queryRecentEvents: vi.fn(() => []),
+  queryEventsByType: vi.fn(() => []),
+}))
+
+const { queryRecentEvents, queryEventsByType } = await import("../events.js")
+const { eventsApi } = await import("../api/events.js")
+
+const mockRecent = vi.mocked(queryRecentEvents)
+const mockByType = vi.mocked(queryEventsByType)
+
+beforeEach(() => {
+  mockRecent.mockClear()
+  mockByType.mockClear()
+})
+
+describe("GET /events limit parameter", () => {
+  it("defaults to 100 when limit is not specified", async () => {
+    const res = await eventsApi.request("/")
+    expect(res.status).toBe(200)
+    expect(mockRecent).toHaveBeenCalledWith(100)
+  })
+
+  it("uses the provided numeric limit", async () => {
+    const res = await eventsApi.request("/?limit=50")
+    expect(res.status).toBe(200)
+    expect(mockRecent).toHaveBeenCalledWith(50)
+  })
+
+  it("caps limit at 500", async () => {
+    const res = await eventsApi.request("/?limit=999")
+    expect(res.status).toBe(200)
+    expect(mockRecent).toHaveBeenCalledWith(500)
+  })
+
+  it("falls back to 100 when limit is NaN string like 'abc'", async () => {
+    const res = await eventsApi.request("/?limit=abc")
+    expect(res.status).toBe(200)
+    expect(mockRecent).toHaveBeenCalledWith(100)
+  })
+
+  it("falls back to 100 when limit is 'NaN'", async () => {
+    const res = await eventsApi.request("/?limit=NaN")
+    expect(res.status).toBe(200)
+    expect(mockRecent).toHaveBeenCalledWith(100)
+  })
+
+  it("passes limit to queryEventsByType when type is specified", async () => {
+    const res = await eventsApi.request("/?type=task.started&limit=25")
+    expect(res.status).toBe(200)
+    expect(mockByType).toHaveBeenCalledWith("task.started", 25)
+  })
+})

--- a/packages/daemon/src/api/events.ts
+++ b/packages/daemon/src/api/events.ts
@@ -6,7 +6,8 @@ export const eventsApi = new Hono()
 
 // GET /events — 直近のイベント一覧
 eventsApi.get("/", (c) => {
-  const limit = Math.min(Number(c.req.query("limit") ?? 100), 500)
+  const raw = Number(c.req.query("limit") ?? 100)
+  const limit = Math.min(Number.isFinite(raw) ? raw : 100, 500)
   const type = c.req.query("type") as AgentEvent["type"] | undefined
   const events = type ? queryEventsByType(type, limit) : queryRecentEvents(limit)
   return c.json(events)


### PR DESCRIPTION
## Summary
Task: `01KKTGMYPE580WNY22M82HHHK1`

**Changes:** 2 files (+57/-1)

### Files
- `packages/daemon/src/__tests__/events-api-limit.test.ts`
- `packages/daemon/src/api/events.ts`

---
Auto-generated by DevPane autonomous agent