### PR TITLE
task-01KKTFZP07JRRWS3YXJYJKG0Q3: facts.tsのビルド・テスト・lintタイムアウトをconfig.tsに外出し

### DIFF
--- a/packages/daemon/src/__tests__/facts-timeout-config.test.ts
+++ b/packages/daemon/src/__tests__/facts-timeout-config.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyConfig = Record<string, any>
+
+async function loadConfig(): Promise<AnyConfig> {
+  const mod = await vi.importActual<{ config: AnyConfig }>("../config.js")
+  return mod.config
+}
+
+describe("facts timeout config", () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  // --- BUILD_TIMEOUT_MS ---
+
+  it("uses default BUILD_TIMEOUT_MS=120000 when env not set", async () => {
+    delete process.env.BUILD_TIMEOUT_MS
+    const config = await loadConfig()
+    expect(config.BUILD_TIMEOUT_MS).toBe(120000)
+  })
+
+  it("overrides BUILD_TIMEOUT_MS from env", async () => {
+    vi.stubEnv("BUILD_TIMEOUT_MS", "300000")
+    const config = await loadConfig()
+    expect(config.BUILD_TIMEOUT_MS).toBe(300000)
+    vi.unstubAllEnvs()
+  })
+
+  // --- TEST_TIMEOUT_MS ---
+
+  it("uses default TEST_TIMEOUT_MS=120000 when env not set", async () => {
+    delete process.env.TEST_TIMEOUT_MS
+    const config = await loadConfig()
+    expect(config.TEST_TIMEOUT_MS).toBe(120000)
+  })
+
+  it("overrides TEST_TIMEOUT_MS from env", async () => {
+    vi.stubEnv("TEST_TIMEOUT_MS", "240000")
+    const config = await loadConfig()
+    expect(config.TEST_TIMEOUT_MS).toBe(240000)
+    vi.unstubAllEnvs()
+  })
+
+  // --- LINT_TIMEOUT_MS ---
+
+  it("uses default LINT_TIMEOUT_MS=60000 when env not set", async () => {
+    delete process.env.LINT_TIMEOUT_MS
+    const config = await loadConfig()
+    expect(config.LINT_TIMEOUT_MS).toBe(60000)
+  })
+
+  it("overrides LINT_TIMEOUT_MS from env", async () => {
+    vi.stubEnv("LINT_TIMEOUT_MS", "180000")
+    const config = await loadConfig()
+    expect(config.LINT_TIMEOUT_MS).toBe(180000)
+    vi.unstubAllEnvs()
+  })
+})

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -43,6 +43,9 @@ export const config: Config = {
   TEST_FILE_PATTERN: env("DEVPANE_TEST_FILE_PATTERN", "*.test.ts"),
   TEST_FRAMEWORK: env("DEVPANE_TEST_FRAMEWORK", "vitest"),
   PR_MERGE_STRATEGY: env("DEVPANE_PR_MERGE_STRATEGY", "--merge"),
+  BUILD_TIMEOUT_MS: Number(env("BUILD_TIMEOUT_MS", "120000")),
+  TEST_TIMEOUT_MS: Number(env("TEST_TIMEOUT_MS", "120000")),
+  LINT_TIMEOUT_MS: Number(env("LINT_TIMEOUT_MS", "60000")),
 }
 
 export function parseCmd(cmd: string): { bin: string; args: string[] } {

--- a/packages/daemon/src/facts.ts
+++ b/packages/daemon/src/facts.ts
@@ -23,7 +23,7 @@ export function collectFacts(
     execFileSync(build.bin, build.args, {
       cwd: worktreePath,
       encoding: "utf-8",
-      timeout: 120000,
+      timeout: config.BUILD_TIMEOUT_MS,
     })
   } catch (e) {
     buildFailed = true
@@ -42,7 +42,7 @@ export function collectFacts(
       const result = execFileSync(test.bin, test.args, {
         cwd: worktreePath,
         encoding: "utf-8",
-        timeout: 120000,
+        timeout: config.TEST_TIMEOUT_MS,
       })
       const passMatch = result.match(/(\d+)\s+pass/i)
       const failMatch = result.match(/(\d+)\s+fail/i)
@@ -80,7 +80,7 @@ export function collectFacts(
       const result = execFileSync(lint.bin, lint.args, {
         cwd: worktreePath,
         encoding: "utf-8",
-        timeout: 60000,
+        timeout: config.LINT_TIMEOUT_MS,
       })
       // Count error lines from typical lint output
       const errorMatch = result.match(/(\d+)\s+errors?/i)

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -136,4 +136,7 @@ export type Config = {
   TEST_FILE_PATTERN: string
   TEST_FRAMEWORK: string
   PR_MERGE_STRATEGY: string
+  BUILD_TIMEOUT_MS: number
+  TEST_TIMEOUT_MS: number
+  LINT_TIMEOUT_MS: number
 }


### PR DESCRIPTION
## Summary
Task: `01KKTFZP07JRRWS3YXJYJKG0Q3`

**Changes:** 4 files (+69/-3)

### Files
- `packages/daemon/src/__tests__/facts-timeout-config.test.ts`
- `packages/daemon/src/config.ts`
- `packages/daemon/src/facts.ts`
- `packages/shared/src/types.ts`

---
Auto-generated by DevPane autonomous agent