### PR TITLE
task-01KKW9R7K6371XV01VSDZ7P426: appendLogにtry-catchを追加しDB例外でスケジューラがクラッシュしない耐性を確保

### DIFF
--- a/packages/daemon/src/__tests__/appendlog-resilience.test.ts
+++ b/packages/daemon/src/__tests__/appendlog-resilience.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import { initDb, closeDb } from "../db/core.js"
+import { appendLog, getTaskLogs, createTask } from "../db/tasks.js"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsDir = join(__dirname, "..", "..", "src", "migrations")
+
+describe("appendLog resilience", () => {
+  beforeEach(() => {
+    initDb(":memory:", migrationsDir)
+  })
+
+  afterEach(() => {
+    closeDb()
+    vi.restoreAllMocks()
+  })
+
+  it("does not throw when getDb().prepare() throws", async () => {
+    const { getDb } = await import("../db/core.js")
+    const origPrepare = getDb().prepare.bind(getDb())
+    vi.spyOn(getDb(), "prepare").mockImplementation((sql: string) => {
+      if (sql.includes("INSERT INTO task_logs")) {
+        throw new Error("SQLITE_BUSY: database is locked")
+      }
+      return origPrepare(sql)
+    })
+
+    expect(() => appendLog("task-1", "worker-0", "test message")).not.toThrow()
+  })
+
+  it("emits console.warn when DB insert fails", async () => {
+    const { getDb } = await import("../db/core.js")
+    const origPrepare = getDb().prepare.bind(getDb())
+    vi.spyOn(getDb(), "prepare").mockImplementation((sql: string) => {
+      if (sql.includes("INSERT INTO task_logs")) {
+        throw new Error("SQLITE_FULL: disk full")
+      }
+      return origPrepare(sql)
+    })
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    appendLog("task-1", "worker-0", "test message")
+
+    expect(warnSpy).toHaveBeenCalledOnce()
+    expect(warnSpy.mock.calls[0][0]).toContain("[appendLog]")
+    expect(warnSpy.mock.calls[0][0]).toContain("task-1")
+  })
+
+  it("inserts log normally when DB is healthy", () => {
+    const task = createTask("Test", "desc", "pm")
+    appendLog(task.id, "worker-0", "hello")
+    appendLog(task.id, "worker-0", "world")
+
+    const logs = getTaskLogs(task.id)
+    expect(logs).toHaveLength(2)
+    expect(logs[0].message).toBe("hello")
+    expect(logs[1].message).toBe("world")
+  })
+})

--- a/packages/daemon/src/db/tasks.ts
+++ b/packages/daemon/src/db/tasks.ts
@@ -73,8 +73,12 @@ export function updateTaskCost(id: string, costUsd: number, tokensUsed: number):
 }
 
 export function appendLog(taskId: string, agent: string, message: string): void {
-  const id = ulid()
-  getDb().prepare(`INSERT INTO task_logs (id, task_id, agent, message, timestamp) VALUES (?, ?, ?, ?, ?)`).run(id, taskId, agent, message, new Date().toISOString())
+  try {
+    const id = ulid()
+    getDb().prepare(`INSERT INTO task_logs (id, task_id, agent, message, timestamp) VALUES (?, ?, ?, ?, ?)`).run(id, taskId, agent, message, new Date().toISOString())
+  } catch (err) {
+    console.warn(`[appendLog] failed for task ${taskId}:`, err)
+  }
 }
 
 export function getTaskLogs(taskId: string): TaskLog[] {


### PR DESCRIPTION
## Summary
Task: `01KKW9R7K6371XV01VSDZ7P426`

**Changes:** 2 files (+67/-2)

### Files
- `packages/daemon/src/__tests__/appendlog-resilience.test.ts`
- `packages/daemon/src/db/tasks.ts`

---
Auto-generated by DevPane autonomous agent