### PR TITLE
task-01KKWA7QMEGPBMPP2HA7EQC2VY: scheduler.tsとscheduler-plugins.tsのparseConstraints重複定義を共通化

### DIFF
--- a/packages/daemon/src/__tests__/countOpenPrs-failure.test.ts
+++ b/packages/daemon/src/__tests__/countOpenPrs-failure.test.ts
@@ -105,6 +105,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   resetKaizenCounter: vi.fn(),
   setKaizenCounter: vi.fn(),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
 }))
 
 vi.mock("../spc.js", () => ({

--- a/packages/daemon/src/__tests__/gate-memory.test.ts
+++ b/packages/daemon/src/__tests__/gate-memory.test.ts
@@ -28,6 +28,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   setEffectMeasureCounter: vi.fn(),
   getEffectMeasureCounter: vi.fn(() => 0),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
   KAIZEN_THRESHOLD: 10,
   checkKaizenAnalysis: vi.fn(),
   resetKaizenCounter: vi.fn(),

--- a/packages/daemon/src/__tests__/gate-rejected-events.test.ts
+++ b/packages/daemon/src/__tests__/gate-rejected-events.test.ts
@@ -29,6 +29,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   setEffectMeasureCounter: vi.fn(),
   getEffectMeasureCounter: vi.fn(() => 0),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
   KAIZEN_THRESHOLD: 10,
   checkKaizenAnalysis: vi.fn(),
   resetKaizenCounter: vi.fn(),

--- a/packages/daemon/src/__tests__/gate1-recycle-retry.test.ts
+++ b/packages/daemon/src/__tests__/gate1-recycle-retry.test.ts
@@ -28,6 +28,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   setEffectMeasureCounter: vi.fn(),
   getEffectMeasureCounter: vi.fn(() => 0),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
   KAIZEN_THRESHOLD: 10,
   checkKaizenAnalysis: vi.fn(),
   resetKaizenCounter: vi.fn(),

--- a/packages/daemon/src/__tests__/gate3-pass-no-started.test.ts
+++ b/packages/daemon/src/__tests__/gate3-pass-no-started.test.ts
@@ -29,6 +29,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   setEffectMeasureCounter: vi.fn(),
   getEffectMeasureCounter: vi.fn(() => 0),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
   KAIZEN_THRESHOLD: 10,
   checkKaizenAnalysis: vi.fn(),
   resetKaizenCounter: vi.fn(),

--- a/packages/daemon/src/__tests__/gate3-recycle-event.test.ts
+++ b/packages/daemon/src/__tests__/gate3-recycle-event.test.ts
@@ -29,6 +29,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   setEffectMeasureCounter: vi.fn(),
   getEffectMeasureCounter: vi.fn(() => 0),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
   KAIZEN_THRESHOLD: 10,
   checkKaizenAnalysis: vi.fn(),
   resetKaizenCounter: vi.fn(),

--- a/packages/daemon/src/__tests__/parse-constraints-shared.test.ts
+++ b/packages/daemon/src/__tests__/parse-constraints-shared.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest"
+import { parseConstraints } from "../scheduler-plugins.js"
+
+describe("parseConstraints (shared from scheduler-plugins)", () => {
+  it("returns empty array for null", () => {
+    expect(parseConstraints(null)).toEqual([])
+  })
+
+  it("returns empty array for empty string", () => {
+    expect(parseConstraints("")).toEqual([])
+  })
+
+  it("parses valid JSON string array", () => {
+    expect(parseConstraints('["a","b","c"]')).toEqual(["a", "b", "c"])
+  })
+
+  it("filters out non-string elements", () => {
+    expect(parseConstraints('[1,"valid",true,null,"also valid"]')).toEqual([
+      "valid",
+      "also valid",
+    ])
+  })
+
+  it("returns empty array for malformed JSON", () => {
+    expect(parseConstraints("{not json")).toEqual([])
+  })
+
+  it("returns empty array for non-array JSON", () => {
+    expect(parseConstraints('{"key":"value"}')).toEqual([])
+  })
+
+  it("returns empty array for JSON string (not array)", () => {
+    expect(parseConstraints('"just a string"')).toEqual([])
+  })
+})

--- a/packages/daemon/src/__tests__/pipeline-e2e.test.ts
+++ b/packages/daemon/src/__tests__/pipeline-e2e.test.ts
@@ -32,6 +32,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   setEffectMeasureCounter: vi.fn(),
   getEffectMeasureCounter: vi.fn(() => 0),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
   KAIZEN_THRESHOLD: 10,
   checkKaizenAnalysis: vi.fn(),
   resetKaizenCounter: vi.fn(),

--- a/packages/daemon/src/__tests__/pm-backoff-pause.test.ts
+++ b/packages/daemon/src/__tests__/pm-backoff-pause.test.ts
@@ -106,6 +106,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   resetKaizenCounter: vi.fn(),
   setKaizenCounter: vi.fn(),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
 }))
 
 vi.mock("../discord.js", () => ({

--- a/packages/daemon/src/__tests__/pr-fail-metrics.test.ts
+++ b/packages/daemon/src/__tests__/pr-fail-metrics.test.ts
@@ -33,6 +33,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   resetKaizenCounter: vi.fn(),
   setKaizenCounter: vi.fn(),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
 }))
 
 vi.mock("../scheduler-hooks.js", async (importOriginal) => {

--- a/packages/daemon/src/__tests__/pr-fail-no-hooks.test.ts
+++ b/packages/daemon/src/__tests__/pr-fail-no-hooks.test.ts
@@ -29,6 +29,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   setEffectMeasureCounter: vi.fn(),
   getEffectMeasureCounter: vi.fn(() => 0),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
   KAIZEN_THRESHOLD: 10,
   checkKaizenAnalysis: vi.fn(),
   resetKaizenCounter: vi.fn(),

--- a/packages/daemon/src/__tests__/scheduler-active-hours.test.ts
+++ b/packages/daemon/src/__tests__/scheduler-active-hours.test.ts
@@ -98,6 +98,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   resetKaizenCounter: vi.fn(),
   setKaizenCounter: vi.fn(),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
 }))
 
 vi.mock("../discord.js", () => ({

--- a/packages/daemon/src/__tests__/scheduler-catch-broadcast.test.ts
+++ b/packages/daemon/src/__tests__/scheduler-catch-broadcast.test.ts
@@ -29,6 +29,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   setEffectMeasureCounter: vi.fn(),
   getEffectMeasureCounter: vi.fn(() => 0),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
   KAIZEN_THRESHOLD: 10,
   checkKaizenAnalysis: vi.fn(),
   resetKaizenCounter: vi.fn(),

--- a/packages/daemon/src/__tests__/scheduler-circuit-pause.test.ts
+++ b/packages/daemon/src/__tests__/scheduler-circuit-pause.test.ts
@@ -107,6 +107,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   resetKaizenCounter: vi.fn(),
   setKaizenCounter: vi.fn(),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
 }))
 
 vi.mock("../discord.js", () => ({

--- a/packages/daemon/src/__tests__/scheduler-haspr-logic.test.ts
+++ b/packages/daemon/src/__tests__/scheduler-haspr-logic.test.ts
@@ -29,6 +29,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   setEffectMeasureCounter: vi.fn(),
   getEffectMeasureCounter: vi.fn(() => 0),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
   KAIZEN_THRESHOLD: 10,
   checkKaizenAnalysis: vi.fn(),
   resetKaizenCounter: vi.fn(),

--- a/packages/daemon/src/__tests__/scheduler-periodic-prune.test.ts
+++ b/packages/daemon/src/__tests__/scheduler-periodic-prune.test.ts
@@ -108,6 +108,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   resetKaizenCounter: vi.fn(),
   setKaizenCounter: vi.fn(),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
 }))
 
 vi.mock("../discord.js", () => ({

--- a/packages/daemon/src/__tests__/scheduler-sleep-pause.test.ts
+++ b/packages/daemon/src/__tests__/scheduler-sleep-pause.test.ts
@@ -109,6 +109,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   resetKaizenCounter: vi.fn(),
   setKaizenCounter: vi.fn(),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
 }))
 
 vi.mock("../discord.js", () => ({

--- a/packages/daemon/src/__tests__/scheduler-spc-failed.test.ts
+++ b/packages/daemon/src/__tests__/scheduler-spc-failed.test.ts
@@ -126,6 +126,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   resetKaizenCounter: vi.fn(),
   setKaizenCounter: vi.fn(),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
 }))
 
 function makeTask(overrides: Partial<Task> = {}): Task {

--- a/packages/daemon/src/__tests__/scheduler-task-failed-hooks.test.ts
+++ b/packages/daemon/src/__tests__/scheduler-task-failed-hooks.test.ts
@@ -27,6 +27,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   setEffectMeasureCounter: vi.fn(),
   getEffectMeasureCounter: vi.fn(() => 0),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
   KAIZEN_THRESHOLD: 10,
   checkKaizenAnalysis: vi.fn(),
   resetKaizenCounter: vi.fn(),

--- a/packages/daemon/src/__tests__/scheduler-worktree-fail.test.ts
+++ b/packages/daemon/src/__tests__/scheduler-worktree-fail.test.ts
@@ -25,6 +25,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   setEffectMeasureCounter: vi.fn(),
   getEffectMeasureCounter: vi.fn(() => 0),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
   KAIZEN_THRESHOLD: 10,
   checkKaizenAnalysis: vi.fn(),
   resetKaizenCounter: vi.fn(),

--- a/packages/daemon/src/__tests__/tester-timeout-metrics.test.ts
+++ b/packages/daemon/src/__tests__/tester-timeout-metrics.test.ts
@@ -33,6 +33,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   resetKaizenCounter: vi.fn(),
   setKaizenCounter: vi.fn(),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
 }))
 
 vi.mock("../scheduler-hooks.js", async (importOriginal) => {

--- a/packages/daemon/src/__tests__/tester-timeout-skip-worker.test.ts
+++ b/packages/daemon/src/__tests__/tester-timeout-skip-worker.test.ts
@@ -32,6 +32,7 @@ vi.mock("../scheduler-plugins.js", () => ({
   setEffectMeasureCounter: vi.fn(),
   getEffectMeasureCounter: vi.fn(() => 0),
   getKaizenCounter: vi.fn(() => 0),
+  parseConstraints: (raw: string | null) => { if (!raw) return []; try { const p = JSON.parse(raw); if (Array.isArray(p)) return p.filter((s: unknown): s is string => typeof s === "string"); } catch {} return [] },
   KAIZEN_THRESHOLD: 10,
   checkKaizenAnalysis: vi.fn(),
   resetKaizenCounter: vi.fn(),

--- a/packages/daemon/src/scheduler-plugins.ts
+++ b/packages/daemon/src/scheduler-plugins.ts
@@ -159,7 +159,7 @@ registerHook("task.completed", () => {
   }
 })
 
-function parseConstraints(raw: string | null): string[] {
+export function parseConstraints(raw: string | null): string[] {
   if (!raw) return []
   try {
     const parsed = JSON.parse(raw)

--- a/packages/daemon/src/scheduler.ts
+++ b/packages/daemon/src/scheduler.ts
@@ -18,6 +18,7 @@ import { remember } from "./memory.js"
 import { recordTaskMetrics } from "./spc.js"
 // Side-effect import: registers all scheduler hooks (SPC, memory, effect measurement)
 import "./scheduler-plugins.js"
+import { parseConstraints } from "./scheduler-plugins.js"
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -34,15 +35,6 @@ export function calculatePmBackoff(consecutiveFailures: number): number {
   if (cooldownCount <= 0) return PM_BACKOFF_BASE_SEC
   const backoff = PM_BACKOFF_BASE_SEC * Math.pow(2, cooldownCount - 1)
   return Math.min(backoff, PM_BACKOFF_MAX_SEC)
-}
-
-function parseConstraints(raw: string | null): string[] {
-  if (!raw) return []
-  try {
-    const parsed = JSON.parse(raw)
-    if (Array.isArray(parsed)) return parsed.filter((s): s is string => typeof s === "string")
-  } catch { /* ignore malformed JSON */ }
-  return []
 }
 
 const RATE_LIMIT_PATTERNS = [


### PR DESCRIPTION
## Summary
Task: `01KKWA7QMEGPBMPP2HA7EQC2VY`

**Changes:** 24 files (+58/-10)

### Files
- `packages/daemon/src/__tests__/countOpenPrs-failure.test.ts`
- `packages/daemon/src/__tests__/gate-memory.test.ts`
- `packages/daemon/src/__tests__/gate-rejected-events.test.ts`
- `packages/daemon/src/__tests__/gate1-recycle-retry.test.ts`
- `packages/daemon/src/__tests__/gate3-pass-no-started.test.ts`
- `packages/daemon/src/__tests__/gate3-recycle-event.test.ts`
- `packages/daemon/src/__tests__/parse-constraints-shared.test.ts`
- `packages/daemon/src/__tests__/pipeline-e2e.test.ts`
- `packages/daemon/src/__tests__/pm-backoff-pause.test.ts`
- `packages/daemon/src/__tests__/pr-fail-metrics.test.ts`
- `packages/daemon/src/__tests__/pr-fail-no-hooks.test.ts`
- `packages/daemon/src/__tests__/scheduler-active-hours.test.ts`
- `packages/daemon/src/__tests__/scheduler-catch-broadcast.test.ts`
- `packages/daemon/src/__tests__/scheduler-circuit-pause.test.ts`
- `packages/daemon/src/__tests__/scheduler-haspr-logic.test.ts`
- `packages/daemon/src/__tests__/scheduler-periodic-prune.test.ts`
- `packages/daemon/src/__tests__/scheduler-sleep-pause.test.ts`
- `packages/daemon/src/__tests__/scheduler-spc-failed.test.ts`
- `packages/daemon/src/__tests__/scheduler-task-failed-hooks.test.ts`
- `packages/daemon/src/__tests__/scheduler-worktree-fail.test.ts`
- `packages/daemon/src/__tests__/tester-timeout-metrics.test.ts`
- `packages/daemon/src/__tests__/tester-timeout-skip-worker.test.ts`
- `packages/daemon/src/scheduler-plugins.ts`
- `packages/daemon/src/scheduler.ts`

---
Auto-generated by DevPane autonomous agent