### PR TITLE
task-01KKWB7WH195NYDNVCZDRPXMEV: gate.tsのclassifyRootCauseでlintエラーをscope_creepに誤分類している問題の修正

### DIFF
--- a/packages/daemon/src/__tests__/gate-classify.test.ts
+++ b/packages/daemon/src/__tests__/gate-classify.test.ts
@@ -37,18 +37,18 @@ describe("classifyRootCause — exhaustive branch coverage", () => {
 
   // --- lint_error detection ---
   describe("lint_error detection", () => {
-    it("returns scope_creep when lint_result has errors", () => {
+    it("returns code_quality when lint_result has errors", () => {
       const facts = makeFacts({
         lint_result: { errors: 5, exit_code: 1 },
       })
-      expect(classifyRootCause(facts, ["lint errors: 5"])).toBe("scope_creep")
+      expect(classifyRootCause(facts, ["lint errors: 5"])).toBe("code_quality")
     })
 
     it("does not trigger for lint_result with zero errors", () => {
       const facts = makeFacts({
         lint_result: { errors: 0, exit_code: 0 },
       })
-      expect(classifyRootCause(facts, [])).not.toBe("scope_creep")
+      expect(classifyRootCause(facts, [])).not.toBe("code_quality")
     })
   })
 
@@ -142,7 +142,7 @@ describe("classifyRootCause — exhaustive branch coverage", () => {
         lint_result: { errors: 1, exit_code: 1 },
         diff_stats: { additions: config.MAX_DIFF_SIZE + 100, deletions: 0 },
       })
-      expect(classifyRootCause(facts, [])).toBe("scope_creep")
+      expect(classifyRootCause(facts, [])).toBe("code_quality")
     })
 
     it("diff_size takes priority over timeout in reasons (when no timed_out flag)", () => {

--- a/packages/daemon/src/__tests__/gate-root-cause.test.ts
+++ b/packages/daemon/src/__tests__/gate-root-cause.test.ts
@@ -79,11 +79,19 @@ describe("classifyRootCause", () => {
     expect(classifyRootCause(facts, ["tests failed: 2"])).toBe("test_gap")
   })
 
-  it("returns scope_creep when lint errors exist", () => {
+  it("returns code_quality when lint errors exist", () => {
     const facts = makeFacts({
       lint_result: { errors: 3, exit_code: 1 },
     })
-    expect(classifyRootCause(facts, ["lint errors: 3"])).toBe("scope_creep")
+    expect(classifyRootCause(facts, ["lint errors: 3"])).toBe("code_quality")
+  })
+
+  it("returns code_quality (not scope_creep) for lint-only failures", () => {
+    const facts = makeFacts({
+      lint_result: { errors: 1, exit_code: 1 },
+    })
+    expect(classifyRootCause(facts, ["lint errors: 1"])).not.toBe("scope_creep")
+    expect(classifyRootCause(facts, ["lint errors: 1"])).toBe("code_quality")
   })
 
   it("returns scope_creep when diff is oversized", () => {

--- a/packages/daemon/src/__tests__/gate.test.ts
+++ b/packages/daemon/src/__tests__/gate.test.ts
@@ -53,7 +53,7 @@ describe("Gate 3", () => {
       lint_result: { errors: 3, exit_code: 1 },
     }))
     expect(result.verdict).toBe("recycle")
-    expect(result.failure?.root_cause).toBe("scope_creep")
+    expect(result.failure?.root_cause).toBe("code_quality")
   })
 
   it("recycles task with oversized diff", () => {

--- a/packages/daemon/src/gate.ts
+++ b/packages/daemon/src/gate.ts
@@ -80,7 +80,7 @@ export function runGate3(taskId: string, facts: ObservableFacts): Gate3Result {
 export function classifyRootCause(facts: ObservableFacts, reasons: string[]): RootCauseType {
   if (facts.test_result?.timed_out) return "env_issue"
   if (facts.test_result?.failed && facts.test_result.failed > 0) return "test_gap"
-  if (facts.lint_result?.errors && facts.lint_result.errors > 0) return "scope_creep"
+  if (facts.lint_result?.errors && facts.lint_result.errors > 0) return "code_quality"
   const diffSize = facts.diff_stats.additions + facts.diff_stats.deletions
   if (diffSize > config.MAX_DIFF_SIZE) return "scope_creep"
   if (reasons.some(r => /timeout/i.test(r))) return "env_issue"

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -21,6 +21,7 @@ export const RootCause = z.enum([
   "spec_ambiguity",
   "test_gap",
   "scope_creep",
+  "code_quality",
   "api_misuse",
   "env_issue",
   "regression",


### PR DESCRIPTION
## Summary
Task: `01KKWB7WH195NYDNVCZDRPXMEV`

**Changes:** 5 files (+17/-8)

### Files
- `packages/daemon/src/__tests__/gate-classify.test.ts`
- `packages/daemon/src/__tests__/gate-root-cause.test.ts`
- `packages/daemon/src/__tests__/gate.test.ts`
- `packages/daemon/src/gate.ts`
- `packages/shared/src/schemas.ts`

---
Auto-generated by DevPane autonomous agent