### PR TITLE
task-01KKWCTZYV339JFH6KPD3J8Z2T: TasksView.vueにfailed/doneフィルタ時のパイプライントレース列を追加

### DIFF
--- a/packages/daemon/src/__tests__/tasks-traces-api.test.ts
+++ b/packages/daemon/src/__tests__/tasks-traces-api.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import { Hono } from "hono"
+import { initDb, closeDb, createTask, finishTask, startTask } from "../db.js"
+import { insertAgentEvent } from "../db/events.js"
+import { tasksApi } from "../api/tasks.js"
+
+import type { PipelineTrace } from "../pipeline-trace.js"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsDir = join(__dirname, "..", "..", "src", "migrations")
+
+function buildApp() {
+  const app = new Hono()
+  app.route("/tasks", tasksApi)
+  return app
+}
+
+describe("GET /tasks/traces", () => {
+  let app: Hono
+
+  beforeEach(() => {
+    initDb(":memory:", migrationsDir)
+    app = buildApp()
+  })
+
+  afterEach(() => {
+    closeDb()
+  })
+
+  it("returns empty array when no done/failed tasks exist", async () => {
+    const res = await app.request("/tasks/traces")
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([])
+  })
+
+  it("returns empty array when only pending tasks exist", async () => {
+    createTask("Pending task", "desc", "human", 50)
+    const res = await app.request("/tasks/traces")
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([])
+  })
+
+  it("returns traces for done tasks", async () => {
+    const task = createTask("Done task", "desc", "pm", 50)
+    startTask(task.id, "worker-0")
+    insertAgentEvent("gate.passed", { type: "gate.passed", taskId: task.id, gate: "gate1" })
+    insertAgentEvent("gate.passed", { type: "gate.passed", taskId: task.id, gate: "gate2" })
+    insertAgentEvent("task.started", { type: "task.started", taskId: task.id, workerId: "worker-0" })
+    insertAgentEvent("gate.passed", { type: "gate.passed", taskId: task.id, gate: "gate3" })
+    insertAgentEvent("task.completed", { type: "task.completed", taskId: task.id, costUsd: 0.05 })
+    finishTask(task.id, "done", "merged")
+
+    const res = await app.request("/tasks/traces")
+    expect(res.status).toBe(200)
+    const body: PipelineTrace[] = await res.json()
+    expect(body).toHaveLength(1)
+    expect(body[0].taskId).toBe(task.id)
+    expect(body[0].title).toBe("Done task")
+    expect(body[0].gate1).toBe("pass")
+    expect(body[0].outcome).toBe("merged")
+  })
+
+  it("returns traces for failed tasks", async () => {
+    const task = createTask("Failed task", "desc", "pm", 50)
+    startTask(task.id, "worker-0")
+    insertAgentEvent("gate.passed", { type: "gate.passed", taskId: task.id, gate: "gate1" })
+    insertAgentEvent("task.started", { type: "task.started", taskId: task.id, workerId: "worker-0" })
+    insertAgentEvent("task.failed", { type: "task.failed", taskId: task.id, rootCause: "test_gap" })
+    finishTask(task.id, "failed", "test_gap")
+
+    const res = await app.request("/tasks/traces")
+    expect(res.status).toBe(200)
+    const body: PipelineTrace[] = await res.json()
+    expect(body).toHaveLength(1)
+    expect(body[0].taskId).toBe(task.id)
+    expect(body[0].outcome).toContain("fail")
+  })
+
+  it("includes both done and failed tasks", async () => {
+    const done = createTask("Done", "desc", "pm", 50)
+    startTask(done.id, "worker-0")
+    insertAgentEvent("task.completed", { type: "task.completed", taskId: done.id, costUsd: 0.01 })
+    finishTask(done.id, "done", "ok")
+
+    const failed = createTask("Failed", "desc", "pm", 50)
+    startTask(failed.id, "worker-0")
+    insertAgentEvent("task.failed", { type: "task.failed", taskId: failed.id, rootCause: "unknown" })
+    finishTask(failed.id, "failed", "error")
+
+    const res = await app.request("/tasks/traces")
+    expect(res.status).toBe(200)
+    const body: PipelineTrace[] = await res.json()
+    expect(body).toHaveLength(2)
+    const ids = body.map((t: PipelineTrace) => t.taskId)
+    expect(ids).toContain(done.id)
+    expect(ids).toContain(failed.id)
+  })
+
+  it("respects default limit of 50", async () => {
+    // Create 55 done tasks
+    for (let i = 0; i < 55; i++) {
+      const task = createTask(`Task ${i}`, "desc", "pm", 50)
+      startTask(task.id, "worker-0")
+      finishTask(task.id, "done", "ok")
+    }
+
+    const res = await app.request("/tasks/traces")
+    expect(res.status).toBe(200)
+    const body: PipelineTrace[] = await res.json()
+    expect(body.length).toBeLessThanOrEqual(50)
+  })
+
+  it("does not include running tasks", async () => {
+    const running = createTask("Running task", "desc", "pm", 50)
+    startTask(running.id, "worker-0")
+    // Don't finish it — it stays running
+
+    const done = createTask("Done task", "desc", "pm", 50)
+    startTask(done.id, "worker-0")
+    finishTask(done.id, "done", "ok")
+
+    const res = await app.request("/tasks/traces")
+    expect(res.status).toBe(200)
+    const body: PipelineTrace[] = await res.json()
+    expect(body).toHaveLength(1)
+    expect(body[0].taskId).toBe(done.id)
+  })
+
+  it("each trace has all required fields", async () => {
+    const task = createTask("Full trace", "desc", "pm", 50)
+    startTask(task.id, "worker-0")
+    finishTask(task.id, "done", "ok")
+
+    const res = await app.request("/tasks/traces")
+    expect(res.status).toBe(200)
+    const body: PipelineTrace[] = await res.json()
+    expect(body).toHaveLength(1)
+
+    const trace = body[0]
+    expect(trace).toHaveProperty("taskId")
+    expect(trace).toHaveProperty("title")
+    expect(trace).toHaveProperty("gate1")
+    expect(trace).toHaveProperty("tester")
+    expect(trace).toHaveProperty("gate2")
+    expect(trace).toHaveProperty("worker")
+    expect(trace).toHaveProperty("gate3")
+    expect(trace).toHaveProperty("outcome")
+    expect(trace).toHaveProperty("costUsd")
+  })
+})

--- a/packages/daemon/src/api/tasks.ts
+++ b/packages/daemon/src/api/tasks.ts
@@ -1,7 +1,18 @@
 import { Hono } from "hono"
-import { getAllTasks, getTask, getTaskLogs, createTask, revertToPending } from "../db.js"
+import { getAllTasks, getTask, getTaskLogs, createTask, revertToPending, getTasksByStatus } from "../db.js"
+import { traceTask } from "../pipeline-trace.js"
 
 export const tasksApi = new Hono()
+
+tasksApi.get("/traces", (c) => {
+  const limit = 50
+  const doneTasks = getTasksByStatus("done")
+  const failedTasks = getTasksByStatus("failed")
+  const all = [...doneTasks, ...failedTasks]
+    .sort((a, b) => (b.finished_at ?? "").localeCompare(a.finished_at ?? ""))
+    .slice(0, limit)
+  return c.json(all.map(traceTask))
+})
 
 tasksApi.get("/", (c) => {
   const tasks = getAllTasks()

--- a/packages/web/src/__tests__/useApi-fetchTaskTraces.test.ts
+++ b/packages/web/src/__tests__/useApi-fetchTaskTraces.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
+
+// Import after mock setup
+const { fetchTaskTraces } = await import('../composables/useApi')
+
+function jsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: () => Promise.resolve(data),
+  })
+}
+
+describe('fetchTaskTraces', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    fetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fetches traces from /api/tasks/traces', async () => {
+    const traces = [
+      { taskId: 'a', title: 'Task A', gate1: 'pass', tester: 'pass', gate2: 'pass', worker: 'pass', gate3: 'pass', outcome: 'merged', costUsd: 0.02 },
+    ]
+    fetchMock.mockReturnValue(jsonResponse(traces))
+
+    const result = await fetchTaskTraces()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const url = fetchMock.mock.calls[0][0] as string
+    expect(url).toBe('/api/tasks/traces')
+    expect(result).toEqual(traces)
+  })
+
+  it('returns empty array when no traces', async () => {
+    fetchMock.mockReturnValue(jsonResponse([]))
+
+    const result = await fetchTaskTraces()
+    expect(result).toEqual([])
+  })
+
+  it('throws on non-ok response', async () => {
+    fetchMock.mockReturnValue(jsonResponse({ error: 'server error' }, 500))
+
+    await expect(fetchTaskTraces()).rejects.toThrow(/500/)
+  })
+
+  it('times out after 10 seconds', async () => {
+    fetchMock.mockImplementation((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        if (init?.signal) {
+          init.signal.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted.', 'AbortError'))
+          })
+        }
+      })
+    })
+
+    const promise = fetchTaskTraces()
+    await vi.advanceTimersByTimeAsync(10_000)
+    await expect(promise).rejects.toThrow(/タイムアウト|timeout/i)
+  })
+})

--- a/packages/web/src/composables/useApi.ts
+++ b/packages/web/src/composables/useApi.ts
@@ -86,6 +86,22 @@ export async function retryTask(id: string): Promise<void> {
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
 }
 
+export type PipelineTrace = {
+  taskId: string
+  title: string
+  gate1: string
+  tester: string
+  gate2: string
+  worker: string
+  gate3: string
+  outcome: string
+  costUsd: number
+}
+
+export function fetchTaskTraces(): Promise<PipelineTrace[]> {
+  return fetchJson<PipelineTrace[]>('/tasks/traces')
+}
+
 export type CostStats = {
   total_cost: number
   total_tasks: number


### PR DESCRIPTION
## Summary
Task: `01KKWCTZYV339JFH6KPD3J8Z2T`

**Changes:** 4 files (+250/-1)

### Files
- `packages/daemon/src/__tests__/tasks-traces-api.test.ts`
- `packages/daemon/src/api/tasks.ts`
- `packages/web/src/__tests__/useApi-fetchTaskTraces.test.ts`
- `packages/web/src/composables/useApi.ts`

---
Auto-generated by DevPane autonomous agent