### PR TITLE
task-01KKWDV4EQ9964JMWCNRXGADK1: tester.tsのアイドルタイムアウトがWORKER_TIMEOUT_MSを流用しており独立制御できない問題の修正

### DIFF
--- a/packages/daemon/src/__tests__/config.test.ts
+++ b/packages/daemon/src/__tests__/config.test.ts
@@ -99,6 +99,21 @@ describe("config env overrides", () => {
     vi.unstubAllEnvs()
   })
 
+  // --- TESTER_TIMEOUT_MS ---
+
+  it("uses default TESTER_TIMEOUT_MS=300000 when env not set", async () => {
+    delete process.env.TESTER_TIMEOUT_MS
+    const config = await loadConfig()
+    expect(config.TESTER_TIMEOUT_MS).toBe(300000)
+  })
+
+  it("overrides TESTER_TIMEOUT_MS from TESTER_TIMEOUT_MS env", async () => {
+    vi.stubEnv("TESTER_TIMEOUT_MS", "120000")
+    const config = await loadConfig()
+    expect(config.TESTER_TIMEOUT_MS).toBe(120000)
+    vi.unstubAllEnvs()
+  })
+
   // --- MEMORY_CLEANUP_THRESHOLD ---
 
   it("uses default MEMORY_CLEANUP_THRESHOLD=10 when env not set", async () => {

--- a/packages/daemon/src/__tests__/tester-log-taskid.test.ts
+++ b/packages/daemon/src/__tests__/tester-log-taskid.test.ts
@@ -13,7 +13,7 @@ vi.mock("../events.js", () => ({
 
 vi.mock("../config.js", () => ({
   config: {
-    WORKER_TIMEOUT_MS: 5_000,
+    TESTER_TIMEOUT_MS: 5_000,
   },
 }))
 

--- a/packages/daemon/src/__tests__/tester-stderr-tail.test.ts
+++ b/packages/daemon/src/__tests__/tester-stderr-tail.test.ts
@@ -13,7 +13,7 @@ vi.mock("../events.js", () => ({
 
 vi.mock("../config.js", () => ({
   config: {
-    WORKER_TIMEOUT_MS: 5_000,
+    TESTER_TIMEOUT_MS: 5_000,
   },
 }))
 

--- a/packages/daemon/src/__tests__/tester-stderr.test.ts
+++ b/packages/daemon/src/__tests__/tester-stderr.test.ts
@@ -13,7 +13,7 @@ vi.mock("../events.js", () => ({
 
 vi.mock("../config.js", () => ({
   config: {
-    WORKER_TIMEOUT_MS: 5_000,
+    TESTER_TIMEOUT_MS: 5_000,
   },
 }))
 

--- a/packages/daemon/src/__tests__/tester-timeout.test.ts
+++ b/packages/daemon/src/__tests__/tester-timeout.test.ts
@@ -14,7 +14,7 @@ vi.mock("../events.js", () => ({
 
 vi.mock("../config.js", () => ({
   config: {
-    WORKER_TIMEOUT_MS: 5_000, // short timeout for tests
+    TESTER_TIMEOUT_MS: 5_000, // short timeout for tests
   },
 }))
 

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -17,6 +17,7 @@ export const config: Config = {
   APP_NAME: env("APP_NAME", "DevPane"),
   PROJECT_ROOT: env("PROJECT_ROOT", findGitRoot()),
   WORKER_TIMEOUT_MS: Number(env("WORKER_TIMEOUT_MS", "600000")),
+  TESTER_TIMEOUT_MS: Number(env("TESTER_TIMEOUT_MS", "300000")),
   PM_TIMEOUT_MS: Number(env("PM_TIMEOUT_MS", "300000")),
   IDLE_INTERVAL_SEC: Number(env("IDLE_INTERVAL_SEC", "60")),
   PM_RETRY_INTERVAL_SEC: Number(env("PM_RETRY_INTERVAL_SEC", "30")),

--- a/packages/daemon/src/tester.ts
+++ b/packages/daemon/src/tester.ts
@@ -236,9 +236,9 @@ export function runTester(spec: PmOutput, worktreePath: string, taskId?: string)
     let timedOut = false
     let sigkillCheck: ReturnType<typeof setInterval> | undefined
     const idleCheck = setInterval(() => {
-      if (Date.now() - lastActivity > config.WORKER_TIMEOUT_MS) {
+      if (Date.now() - lastActivity > config.TESTER_TIMEOUT_MS) {
         timedOut = true
-        appendLog(taskId ?? "tester", "tester", `[timeout] no activity for ${config.WORKER_TIMEOUT_MS / 1000}s, killing`)
+        appendLog(taskId ?? "tester", "tester", `[timeout] no activity for ${config.TESTER_TIMEOUT_MS / 1000}s, killing`)
         proc.kill("SIGTERM")
         clearInterval(idleCheck)
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -110,6 +110,7 @@ export type Config = {
   APP_NAME: string
   PROJECT_ROOT: string
   WORKER_TIMEOUT_MS: number
+  TESTER_TIMEOUT_MS: number
   PM_TIMEOUT_MS: number
   IDLE_INTERVAL_SEC: number
   PM_RETRY_INTERVAL_SEC: number


### PR DESCRIPTION
## Summary
Task: `01KKWDV4EQ9964JMWCNRXGADK1`

**Changes:** 8 files (+23/-6)

### Files
- `packages/daemon/src/__tests__/config.test.ts`
- `packages/daemon/src/__tests__/tester-log-taskid.test.ts`
- `packages/daemon/src/__tests__/tester-stderr-tail.test.ts`
- `packages/daemon/src/__tests__/tester-stderr.test.ts`
- `packages/daemon/src/__tests__/tester-timeout.test.ts`
- `packages/daemon/src/config.ts`
- `packages/daemon/src/tester.ts`
- `packages/shared/src/types.ts`

---
Auto-generated by DevPane autonomous agent