### PR TITLE
task-01KKWEVPZ55K2B04G3FRW0E5XP: getPipelineStats()のtasks_todayカウントにfailedタスクを含めて実態と乖離しない集計にする

### DIFF
--- a/packages/daemon/src/__tests__/stats-tasks-today.test.ts
+++ b/packages/daemon/src/__tests__/stats-tasks-today.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import { initDb, closeDb } from "../db.js"
+import { getPipelineStats } from "../db/stats.js"
+import { getDb } from "../db/core.js"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsDir = join(__dirname, "..", "..", "src", "migrations")
+
+function insertTask(id: string, status: string, finishedAt: string): void {
+  const db = getDb()
+  db.prepare(
+    `INSERT INTO tasks (id, title, description, status, priority, created_by, created_at, started_at, finished_at)
+     VALUES (?, ?, ?, ?, 0, 'test', ?, ?, ?)`,
+  ).run(id, `task-${id}`, "desc", status, finishedAt, finishedAt, finishedAt)
+}
+
+describe("stats: tasks_today counts both done and failed", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: new Date("2026-03-17T06:00:00.000Z") })
+    process.env.TZ = "UTC"
+    initDb(":memory:", migrationsDir)
+  })
+
+  afterEach(() => {
+    closeDb()
+    vi.useRealTimers()
+    delete process.env.TZ
+  })
+
+  it("counts done tasks in tasks_today", () => {
+    insertTask("d1", "done", "2026-03-17T03:00:00.000Z")
+    insertTask("d2", "done", "2026-03-17T04:00:00.000Z")
+
+    const stats = getPipelineStats()
+    expect(stats.tasks_today).toBe(2)
+  })
+
+  it("counts failed tasks in tasks_today", () => {
+    insertTask("f1", "failed", "2026-03-17T03:00:00.000Z")
+
+    const stats = getPipelineStats()
+    expect(stats.tasks_today).toBe(1)
+  })
+
+  it("counts mixed done and failed tasks in tasks_today", () => {
+    insertTask("d1", "done", "2026-03-17T02:00:00.000Z")
+    insertTask("f1", "failed", "2026-03-17T03:00:00.000Z")
+    insertTask("d2", "done", "2026-03-17T04:00:00.000Z")
+    insertTask("f2", "failed", "2026-03-17T05:00:00.000Z")
+
+    const stats = getPipelineStats()
+    expect(stats.tasks_today).toBe(4)
+  })
+
+  it("returns tasks_today_done and tasks_today_failed separately", () => {
+    insertTask("d1", "done", "2026-03-17T02:00:00.000Z")
+    insertTask("d2", "done", "2026-03-17T03:00:00.000Z")
+    insertTask("f1", "failed", "2026-03-17T04:00:00.000Z")
+
+    const stats = getPipelineStats()
+    expect(stats.tasks_today_done).toBe(2)
+    expect(stats.tasks_today_failed).toBe(1)
+    expect(stats.tasks_today).toBe(3)
+  })
+
+  it("excludes running/queued tasks from tasks_today", () => {
+    insertTask("d1", "done", "2026-03-17T02:00:00.000Z")
+    insertTask("r1", "running", "2026-03-17T03:00:00.000Z")
+    insertTask("q1", "queued", "2026-03-17T04:00:00.000Z")
+    insertTask("f1", "failed", "2026-03-17T05:00:00.000Z")
+
+    const stats = getPipelineStats()
+    expect(stats.tasks_today).toBe(2)
+  })
+
+  it("excludes yesterday's tasks", () => {
+    insertTask("old", "done", "2026-03-16T23:00:00.000Z")
+    insertTask("old-f", "failed", "2026-03-16T22:00:00.000Z")
+    insertTask("today", "done", "2026-03-17T01:00:00.000Z")
+
+    const stats = getPipelineStats()
+    expect(stats.tasks_today).toBe(1)
+  })
+
+  it("returns zero counts when no tasks exist", () => {
+    const stats = getPipelineStats()
+    expect(stats.tasks_today).toBe(0)
+    expect(stats.tasks_today_done).toBe(0)
+    expect(stats.tasks_today_failed).toBe(0)
+  })
+})

--- a/packages/daemon/src/db/stats.ts
+++ b/packages/daemon/src/db/stats.ts
@@ -42,9 +42,13 @@ export function getPipelineStats() {
   const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString()
 
   const tasksToday = d.prepare(`
-    SELECT COUNT(*) AS cnt FROM tasks
-    WHERE status = 'done' AND finished_at >= ?
-  `).get(startOfToday) as { cnt: number }
+    SELECT
+      COUNT(*) AS cnt,
+      COUNT(*) FILTER (WHERE status = 'done') AS done_cnt,
+      COUNT(*) FILTER (WHERE status = 'failed') AS failed_cnt
+    FROM tasks
+    WHERE status IN ('done', 'failed') AND finished_at >= ?
+  `).get(startOfToday) as { cnt: number; done_cnt: number; failed_cnt: number }
 
   const activeImprovements = d.prepare(`
     SELECT COUNT(*) AS cnt FROM improvements WHERE status = 'active'
@@ -56,6 +60,8 @@ export function getPipelineStats() {
     avg_execution_time: Math.round(avgExec.avg_sec),
     consecutive_failures,
     tasks_today: tasksToday.cnt,
+    tasks_today_done: tasksToday.done_cnt,
+    tasks_today_failed: tasksToday.failed_cnt,
     active_improvements: activeImprovements.cnt,
   }
 }

--- a/packages/daemon/src/morning-report.ts
+++ b/packages/daemon/src/morning-report.ts
@@ -41,6 +41,8 @@ function collectShiftData(since: string): ShiftSummary {
     avg_execution_time: 0,
     consecutive_failures: 0,
     tasks_today: 0,
+    tasks_today_done: 0,
+    tasks_today_failed: 0,
     active_improvements: 0,
   }
   try {

--- a/packages/web/src/composables/useApi.ts
+++ b/packages/web/src/composables/useApi.ts
@@ -124,6 +124,8 @@ export type PipelineStats = {
   avg_execution_time: number
   consecutive_failures: number
   tasks_today: number
+  tasks_today_done: number
+  tasks_today_failed: number
   active_improvements: number
 }
 

--- a/packages/web/src/views/Dashboard.vue
+++ b/packages/web/src/views/Dashboard.vue
@@ -233,7 +233,7 @@ async function send() {
         <div class="stats-bar">
           <template v-if="pipeline">
             <span class="stat">G3通過率: {{ Math.round((pipeline.gate3_pass_rate ?? 0) * 100) }}%</span>
-            <span class="stat">本日: {{ pipeline.tasks_today ?? 0 }}件</span>
+            <span class="stat">完了 {{ pipeline.tasks_today_done ?? 0 }} / 失敗 {{ pipeline.tasks_today_failed ?? 0 }}</span>
             <span class="stat fail" v-if="pipeline.consecutive_failures > 0">連続失敗: {{ pipeline.consecutive_failures }}</span>
           </template>
           <span class="stat warn" v-if="scheduler?.rateLimitHits">RL: {{ scheduler.rateLimitHits }}回</span>


### PR DESCRIPTION
## Summary
Task: `01KKWEVPZ55K2B04G3FRW0E5XP`

**Changes:** 5 files (+107/-4)

### Files
- `packages/daemon/src/__tests__/stats-tasks-today.test.ts`
- `packages/daemon/src/db/stats.ts`
- `packages/daemon/src/morning-report.ts`
- `packages/web/src/composables/useApi.ts`
- `packages/web/src/views/Dashboard.vue`

---
Auto-generated by DevPane autonomous agent