### PR TITLE
task-01KKWGX30ED1F3D79FBAG4WWE6: Dashboard.vueのrecentEventsのv-forキーをインデックスからイベントIDに変更

### DIFF
--- a/packages/web/src/__tests__/dashboard-event-key.test.ts
+++ b/packages/web/src/__tests__/dashboard-event-key.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+
+/**
+ * Dashboard.vue の recentEvents v-for キーが
+ * 配列インデックスではなく e.id を使用していることを検証する。
+ * TDD: 実装前はFAILする。
+ */
+describe('Dashboard recentEvents v-for key', () => {
+  const template = readFileSync(
+    resolve(__dir, '../views/Dashboard.vue'),
+    'utf-8',
+  )
+
+  it('v-for は :key="e.id" を使用する', () => {
+    const vForLine = template
+      .split('\n')
+      .find((line: string) => line.includes('recentEvents') && line.includes('v-for'))
+
+    expect(vForLine).toBeDefined()
+    expect(vForLine).toContain(':key="e.id"')
+    expect(vForLine).not.toMatch(/v-for="\(e,\s*i\)/)
+  })
+})

--- a/packages/web/src/composables/useApi.ts
+++ b/packages/web/src/composables/useApi.ts
@@ -134,6 +134,7 @@ export function fetchPipelineStats(): Promise<PipelineStats> {
 }
 
 export type AgentEvent = {
+  id: string
   type: string
   taskId?: string
   [key: string]: unknown

--- a/packages/web/src/views/Dashboard.vue
+++ b/packages/web/src/views/Dashboard.vue
@@ -345,7 +345,7 @@ async function send() {
       <div class="feed-panel">
         <div class="feed-hdr">イベントフィード</div>
         <div class="feed-log">
-          <div v-for="(e, i) in recentEvents" :key="i" class="feed-item" :class="e.type.includes('failed') || e.type.includes('rejected') ? 'bad' : ''">
+          <div v-for="e in recentEvents" :key="e.id" class="feed-item" :class="e.type.includes('failed') || e.type.includes('rejected') ? 'bad' : ''">
             <span class="feed-icon">{{ eventIcon(e.type) }}</span>
             <span class="feed-text">{{ eventSummary(e) }}</span>
           </div>


### PR DESCRIPTION
## Summary
Task: `01KKWGX30ED1F3D79FBAG4WWE6`

**Changes:** 3 files (+30/-1)

### Files
- `packages/web/src/__tests__/dashboard-event-key.test.ts`
- `packages/web/src/composables/useApi.ts`
- `packages/web/src/views/Dashboard.vue`

---
Auto-generated by DevPane autonomous agent